### PR TITLE
docs: clarify update body replacement and publishing setup

### DIFF
--- a/.no-mistakes/evidence/fm/taxi-docs-d8/npm-pack-dry-run.txt
+++ b/.no-mistakes/evidence/fm/taxi-docs-d8/npm-pack-dry-run.txt
@@ -1,0 +1,51 @@
+
+> tasks-axi@0.1.0 prepack
+> npm run build
+
+
+> tasks-axi@0.1.0 build
+> tsc
+
+npm notice
+npm notice 📦  tasks-axi@0.1.0
+npm notice Tarball Contents
+npm notice 1.1kB LICENSE
+npm notice 9.3kB README.md
+npm notice 103B dist/bin/tasks-axi.js
+npm notice 5.7kB dist/src/args.js
+npm notice 4.9kB dist/src/backends/lock.js
+npm notice 11.2kB dist/src/backends/markdown-grammar.js
+npm notice 24.2kB dist/src/backends/markdown.js
+npm notice 1.9kB dist/src/body.js
+npm notice 6.2kB dist/src/cli.js
+npm notice 15.1kB dist/src/commands/crud.js
+npm notice 2.2kB dist/src/commands/home.js
+npm notice 2.3kB dist/src/commands/maintain.js
+npm notice 1.3kB dist/src/commands/setup.js
+npm notice 13.2kB dist/src/commands/state.js
+npm notice 6.3kB dist/src/config.js
+npm notice 1.0kB dist/src/context.js
+npm notice 1.8kB dist/src/derive.js
+npm notice 904B dist/src/errors.js
+npm notice 1.1kB dist/src/fields.js
+npm notice 809B dist/src/format.js
+npm notice 1.9kB dist/src/id.js
+npm notice 416B dist/src/model.js
+npm notice 4.6kB dist/src/skill.js
+npm notice 44B dist/src/store.js
+npm notice 6.0kB dist/src/suggestions.js
+npm notice 1.7kB dist/src/toon.js
+npm notice 2.8kB dist/src/view.js
+npm notice 1.5kB package.json
+npm notice 3.3kB skills/tasks-axi/SKILL.md
+npm notice Tarball Details
+npm notice name: tasks-axi
+npm notice version: 0.1.0
+npm notice filename: tasks-axi-0.1.0.tgz
+npm notice package size: 35.9 kB
+npm notice unpacked size: 132.9 kB
+npm notice shasum: 2b1892442e49bda3b209784a0ddbf09ee99deaa8
+npm notice integrity: sha512-cPnpEgay6FUp0[...]hMgZUwYIwB7gw==
+npm notice total files: 29
+npm notice
+tasks-axi-0.1.0.tgz

--- a/.no-mistakes/evidence/fm/taxi-docs-d8/update-body-file-notes.md
+++ b/.no-mistakes/evidence/fm/taxi-docs-d8/update-body-file-notes.md
@@ -1,0 +1,2 @@
+file replacement line one
+file replacement line two

--- a/.no-mistakes/evidence/fm/taxi-docs-d8/update-e2e-backlog.md
+++ b/.no-mistakes/evidence/fm/taxi-docs-d8/update-e2e-backlog.md
@@ -1,0 +1,9 @@
+# Backlog
+
+## Queued
+- [ ] nm-release-validation - clearer title (since 2026-06-23)
+  file replacement line one
+  file replacement line two
+  
+## In flight
+## Done

--- a/.no-mistakes/evidence/fm/taxi-docs-d8/update-e2e-transcript.txt
+++ b/.no-mistakes/evidence/fm/taxi-docs-d8/update-e2e-transcript.txt
@@ -1,0 +1,166 @@
+Scratch backlog: .no-mistakes/evidence/fm/taxi-docs-d8/update-e2e-backlog.md
+Scratch body file: .no-mistakes/evidence/fm/taxi-docs-d8/update-body-file-notes.md
+
+$ TASKS_AXI_FILE=.no-mistakes/evidence/fm/taxi-docs-d8/update-e2e-backlog.md node dist/bin/tasks-axi.js update --help
+usage: tasks-axi update <id> [flags]
+aliases: edit
+flags:
+  --title <text>, --body <text> or --body-file <path>, --append "<note>"
+  --repo <name>, --kind <name>, --priority <0-4>, --pr <url>, --report <path>
+examples:
+  tasks-axi update nm-release-validation --append "step 3 in progress on lavish #87"
+  tasks-axi update fm-x --repo firstmate --kind ship
+$ TASKS_AXI_FILE=.no-mistakes/evidence/fm/taxi-docs-d8/update-e2e-backlog.md node dist/bin/tasks-axi.js add nm-release-validation "original title" --body "initial note"
+task:
+  id: nm-release-validation
+  title: original title
+  state: queued
+  blocked: no
+  blocked_by: none
+  kind: task
+  repo: "-"
+  priority: "-"
+  created: 2026-06-23
+  closed: "-"
+  deps: none
+  links: none
+  body: initial note
+help[2]:
+  - Run `tasks-axi start nm-release-validation` to move it to in flight
+  - Run `tasks-axi block nm-release-validation --by <other>` to record a dependency
+
+$ TASKS_AXI_FILE=.no-mistakes/evidence/fm/taxi-docs-d8/update-e2e-backlog.md node dist/bin/tasks-axi.js update nm-release-validation --append "appended note"
+task:
+  id: nm-release-validation
+  title: original title
+  state: queued
+  blocked: no
+  blocked_by: none
+  kind: task
+  repo: "-"
+  priority: "-"
+  created: 2026-06-23
+  closed: "-"
+  deps: none
+  links: none
+  body: "initial note\nappended note"
+help[1]:
+  - Run `tasks-axi show nm-release-validation --full` to see the result
+
+$ TASKS_AXI_FILE=.no-mistakes/evidence/fm/taxi-docs-d8/update-e2e-backlog.md node dist/bin/tasks-axi.js show nm-release-validation --full
+task:
+  id: nm-release-validation
+  title: original title
+  state: queued
+  blocked: no
+  blocked_by: none
+  kind: task
+  repo: "-"
+  priority: "-"
+  created: 2026-06-23
+  closed: "-"
+  deps: none
+  links: none
+  body: "initial note\nappended note"
+
+$ TASKS_AXI_FILE=.no-mistakes/evidence/fm/taxi-docs-d8/update-e2e-backlog.md node dist/bin/tasks-axi.js update nm-release-validation --body "replacement note"
+task:
+  id: nm-release-validation
+  title: original title
+  state: queued
+  blocked: no
+  blocked_by: none
+  kind: task
+  repo: "-"
+  priority: "-"
+  created: 2026-06-23
+  closed: "-"
+  deps: none
+  links: none
+  body: replacement note
+help[1]:
+  - Run `tasks-axi show nm-release-validation --full` to see the result
+
+$ TASKS_AXI_FILE=.no-mistakes/evidence/fm/taxi-docs-d8/update-e2e-backlog.md node dist/bin/tasks-axi.js show nm-release-validation --full
+task:
+  id: nm-release-validation
+  title: original title
+  state: queued
+  blocked: no
+  blocked_by: none
+  kind: task
+  repo: "-"
+  priority: "-"
+  created: 2026-06-23
+  closed: "-"
+  deps: none
+  links: none
+  body: replacement note
+
+$ TASKS_AXI_FILE=.no-mistakes/evidence/fm/taxi-docs-d8/update-e2e-backlog.md node dist/bin/tasks-axi.js update nm-release-validation --body-file .no-mistakes/evidence/fm/taxi-docs-d8/update-body-file-notes.md
+task:
+  id: nm-release-validation
+  title: original title
+  state: queued
+  blocked: no
+  blocked_by: none
+  kind: task
+  repo: "-"
+  priority: "-"
+  created: 2026-06-23
+  closed: "-"
+  deps: none
+  links: none
+  body: "file replacement line one\nfile replacement line two\n"
+help[1]:
+  - Run `tasks-axi show nm-release-validation --full` to see the result
+
+$ TASKS_AXI_FILE=.no-mistakes/evidence/fm/taxi-docs-d8/update-e2e-backlog.md node dist/bin/tasks-axi.js update nm-release-validation --title "clearer title"
+task:
+  id: nm-release-validation
+  title: clearer title
+  state: queued
+  blocked: no
+  blocked_by: none
+  kind: task
+  repo: "-"
+  priority: "-"
+  created: 2026-06-23
+  closed: "-"
+  deps: none
+  links: none
+  body: "file replacement line one\nfile replacement line two\n"
+help[1]:
+  - Run `tasks-axi show nm-release-validation --full` to see the result
+
+$ TASKS_AXI_FILE=.no-mistakes/evidence/fm/taxi-docs-d8/update-e2e-backlog.md node dist/bin/tasks-axi.js show nm-release-validation --full
+task:
+  id: nm-release-validation
+  title: clearer title
+  state: queued
+  blocked: no
+  blocked_by: none
+  kind: task
+  repo: "-"
+  priority: "-"
+  created: 2026-06-23
+  closed: "-"
+  deps: none
+  links: none
+  body: "file replacement line one\nfile replacement line two\n"
+
+$ TASKS_AXI_FILE=.no-mistakes/evidence/fm/taxi-docs-d8/update-e2e-backlog.md node dist/bin/tasks-axi.js update nm-release-validation --body inline --body-file .no-mistakes/evidence/fm/taxi-docs-d8/update-body-file-notes.md
+error: Use only one of --body or --body-file
+code: VALIDATION_ERROR
+exit_status: 2
+
+$ sed -n 1,80p .no-mistakes/evidence/fm/taxi-docs-d8/update-e2e-backlog.md
+# Backlog
+
+## Queued
+- [ ] nm-release-validation - clearer title (since 2026-06-23)
+  file replacement line one
+  file replacement line two
+  
+## In flight
+## Done

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,8 @@ The CLI layer never knows which backend is active — it only talks to the `Stor
 - **Free-form lines (D7)** - any line whose first token is not a clean slug id followed by the delimiter `space-hyphen-space` is preserved verbatim and never operated on by id. A task id is recognized only as `- **id** - …` (in flight), `- [ ] id - …` (queued), `- [x] id - …` (done), where the id is immediately followed by `space-hyphen-space`. This keeps annotated lines like `go-live (CAPTAIN-GATED) - …` and `PR #31 (contributor) - …` free-form (no false positives).
 - **Trailing-tag extraction.** Canonical tags (`(repo: X)`, `(kind: X)`, `(priority: 0-4)`, `(since DATE)`, `(merged|reported|done|closed DATE)`, `blocked-by:/parent:/discovered-from:`) are pulled only off the **trailing** tag-region of a line and re-appended in canonical order on render. This is what makes normalization idempotent: a mid-sentence parenthetical (e.g. `report.md (reported 2026-06-22): …`) or a non-date one (`(closed w/ link)`) is left in the prose and never duplicated or relocated. Date tags require an actual `YYYY-MM-DD`.
 - **Links and leading-word kinds live in the prose**, not as managed tags, so they are never duplicated. `done --pr`/`--report` append the url/path to the title text; links are re-derived by scanning. `kind` comes from a `(kind:)` tag or a leading `SHIP`/`SCOUT`/`DOCS-ONLY`/`PERSISTENT SECONDMATE` word, and the tag is emitted only when the prose does not already lead with that word.
-- **body** = indented (2-space) continuation lines under a bullet; `update --append` grows it. Blank lines inside a body are not preserved (avoid them).
+- **body** = indented (2-space) continuation lines under a bullet; `update --append` adds to it, while `update --body` or `update --body-file` replaces it.
+  Blank lines inside a body are not preserved (avoid them).
 - **Concurrency:** every mutation runs under `withLock` (advisory `<path>.lock`) and fails closed with a `LOCKED` error if another process holds the lock past the bounded timeout.
   If the lock looks stale, the error tells the user to remove `<path>.lock` only after confirming no `tasks-axi` process is running.
   Corruption-safety is guaranteed independently by atomic temp-file + rename writes, and a hand-edit landing between read and write is detected and refused.
@@ -49,7 +50,10 @@ The CLI layer never knows which backend is active — it only talks to the `Stor
 ### Release & packaging (mirrors the `*-axi` siblings)
 
 - **Published to npm as a public package** via `release-please` → `npm publish --access public --provenance` on a release commit (`.github/workflows/release-please.yml`); the captain can also `npm publish` manually. Conventional commits drive the version bump; `release-please-config.json` + `.release-please-manifest.json` own versioning and `CHANGELOG.md`.
-- **The tarball ships runtime JS only.** `package.json` `files` is `dist/**/*.js` (+ `skills/tasks-axi`, `LICENSE`, `README.md`), so the `.d.ts`/`.js.map` that `tsc` emits for local debugging are kept out of the package. `prepack` runs `npm run build`, so `npm pack`/`npm publish` always rebuild `dist` first. Verify with `npm pack --dry-run` (no source/test cruft; bin is `dist/bin/tasks-axi.js` with its shebang preserved by tsc).
+- **The tarball ships runtime JS only.** `package.json` `files` is `dist/**/*.js` (+ `skills/tasks-axi`, `LICENSE`, `README.md`), so the `.d.ts`/`.js.map` that `tsc` emits for local debugging are kept out of the package.
+  `prepack` runs `npm run build`, so `npm pack`/`npm publish` always rebuild `dist` first.
+  In a fresh clone, run `pnpm install --frozen-lockfile` before manual pack or publish.
+  Verify with `npm pack --dry-run` (no source/test cruft; bin is `dist/bin/tasks-axi.js` with its shebang preserved by tsc).
 - **CI is a 3-OS matrix** (ubuntu/macos/windows) running install → build → lint → test → `build:skill --check`. The `Require no-mistakes` and `Guard generated files` checks gate every PR to `main`.
 
 ## Follow-ups (out of P1 scope)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,7 +47,8 @@ The npm package intentionally ships runtime JavaScript only.
 Keep `package.json` `files` limited to `dist/**/*.js`, `skills/tasks-axi`, `LICENSE`, and `README.md`; TypeScript declarations and source maps stay local for development.
 
 `prepack` runs `npm run build`, so `npm pack`, `npm publish`, and `npm publish --dry-run` rebuild `dist` first.
-Before any manual publish, verify the package with `npm pack --dry-run` and keep the CLI bin as `dist/bin/tasks-axi.js` so npm preserves it without warnings.
+From a fresh clone, install dependencies with `pnpm install --frozen-lockfile` before any manual pack or publish, since that build step needs `node_modules` (this matches how CI and the release workflow install).
+Then verify the package with `npm pack --dry-run` and keep the CLI bin as `dist/bin/tasks-axi.js` so npm preserves it without warnings.
 
 ## Questions
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ It borrows the dependency-graph and ready-query model from [beads](https://githu
 
 Every backlog mutation today regenerates markdown through the model, which is expensive output tokens and risks dropped, duplicated, or reordered items.
 tasks-axi reduces that to the length of one short command plus a compact confirmation read back as cheap input.
-The long status line that the model used to rewrite on every status change is now a `body` you grow with `update --append`.
+The long status line that the model used to rewrite on every status change is now a `body`.
+`update --append` adds to that body, while `update --body` / `update --body-file` replace it outright and `update --title` replaces the title.
 
 ## Quick Start
 
@@ -97,8 +98,11 @@ tasks-axi reopen some-task
 tasks-axi block firstmate-lease-adopt --by treehouse-lease-t4
 tasks-axi ready
 
-# grow the long notes without rewriting the whole line
+# edit the body and title: --append adds to the body, --body / --body-file replace it, --title replaces the title
 tasks-axi update nm-release-validation --append "step 3 in progress on lavish #87"
+tasks-axi update nm-release-validation --body "rewritten notes"
+tasks-axi update nm-release-validation --body-file notes.md
+tasks-axi update nm-release-validation --title "clearer title"
 
 # read the full notes on demand (truncated by default)
 tasks-axi show homemux-h7 --full

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ It borrows the dependency-graph and ready-query model from [beads](https://githu
 Every backlog mutation today regenerates markdown through the model, which is expensive output tokens and risks dropped, duplicated, or reordered items.
 tasks-axi reduces that to the length of one short command plus a compact confirmation read back as cheap input.
 The long status line that the model used to rewrite on every status change is now a `body`.
-`update --append` adds to that body, while `update --body` / `update --body-file` replace it outright and `update --title` replaces the title.
+`update --append` adds to that body, while either `update --body` or `update --body-file` replaces it outright and `update --title` replaces the title.
 
 ## Quick Start
 
@@ -98,7 +98,7 @@ tasks-axi reopen some-task
 tasks-axi block firstmate-lease-adopt --by treehouse-lease-t4
 tasks-axi ready
 
-# edit the body and title: --append adds to the body, --body / --body-file replace it, --title replaces the title
+# edit the body and title: --append adds to the body, --body or --body-file replaces it, --title replaces the title
 tasks-axi update nm-release-validation --append "step 3 in progress on lavish #87"
 tasks-axi update nm-release-validation --body "rewritten notes"
 tasks-axi update nm-release-validation --body-file notes.md

--- a/skills/tasks-axi/SKILL.md
+++ b/skills/tasks-axi/SKILL.md
@@ -46,5 +46,5 @@ Run `npx -y tasks-axi --help` for global flags, or `npx -y tasks-axi <command> -
 - Mutations are idempotent and report what changed (`already: true` on a no-op); re-running a mutation is safe.
 - `block <id> --by <other>` and `unblock` manage the dependency graph; `ready` lists only queued work with no unresolved blocker.
 - Filter `list` with `--state`, `--repo`, `--kind`, `--blocked`, `--limit`, and add columns with `--fields a,b,c`.
-- `update <id> --append "<note>"` grows a task's notes without rewriting the whole line; `render` normalizes the file; `mv <id> --to <path>` moves a task to another backlog.
+- `update <id> --append "<note>"` adds to a task's body; `update <id> --body "<text>"` or `--body-file <path>` replaces it, and `--title "<text>"` replaces the title; `render` normalizes the file; `mv <id> --to <path>` moves a task to another backlog.
 - Free-form (no-id) backlog lines are preserved verbatim and are never modified.

--- a/src/skill.ts
+++ b/src/skill.ts
@@ -85,7 +85,7 @@ Run \`npx -y tasks-axi --help\` for global flags, or \`npx -y tasks-axi <command
 - Mutations are idempotent and report what changed (\`already: true\` on a no-op); re-running a mutation is safe.
 - \`block <id> --by <other>\` and \`unblock\` manage the dependency graph; \`ready\` lists only queued work with no unresolved blocker.
 - Filter \`list\` with \`--state\`, \`--repo\`, \`--kind\`, \`--blocked\`, \`--limit\`, and add columns with \`--fields a,b,c\`.
-- \`update <id> --append "<note>"\` grows a task's notes without rewriting the whole line; \`render\` normalizes the file; \`mv <id> --to <path>\` moves a task to another backlog.
+- \`update <id> --append "<note>"\` adds to a task's body; \`update <id> --body "<text>"\` or \`--body-file <path>\` replaces it, and \`--title "<text>"\` replaces the title; \`render\` normalizes the file; \`mv <id> --to <path>\` moves a task to another backlog.
 - Free-form (no-id) backlog lines are preserved verbatim and are never modified.
 `;
 }


### PR DESCRIPTION
## Intent

Fix two documentation gaps in tasks-axi, found while using the published CLI. Keep the diff focused on exactly these two gaps and leave the already-good config/data-resolution docs alone.

1) README: the item body is NOT append-only. The README only showed 'update <id> --append "..."' and described the body as something you 'grow', implying append-only. The CLI's update verb also supports full-replace flags: --body "...", --body-file <path> (replace the body wholesale; --body and --body-file are mutually exclusive), and --title "..." (replace the title). I documented these in both the 'Why' section and the Usage examples, making clear that --append ADDS to the body while --body/--body-file REPLACE it and --title replaces the title. Verified against 'tasks-axi update --help', src/commands/crud.ts, src/body.ts, and src/backends/markdown.ts (patch.body replaces, patch.appendBody concatenates), plus an end-to-end run of the built CLI on a scratch backlog.

2) CONTRIBUTING: the manual-publish instructions ran 'npm pack'/'npm publish' without first installing dependencies, so a fresh clone fails because the prepack build needs node_modules. I added a 'pnpm install --frozen-lockfile' step BEFORE the pack/publish steps. The project uses pnpm; I used --frozen-lockfile to match exactly how .github/workflows/ci.yml and release-please.yml install dependencies.

Markdown prose style: each full sentence is on its own line, per repo convention. No source/behavior changes; docs only. NOTE: prior runs failed only because the no-mistakes daemon crashed under memory pressure at the test step (now resolved); intent+rebase+review passed clean and the real tests/pack/E2E all passed before the crash.

## What Changed

- Clarified README and generated skill docs for `tasks-axi update`: `--append` adds to the body, `--body` and `--body-file` replace it, and `--title` replaces the title.
- Updated manual publish documentation to install dependencies with `pnpm install --frozen-lockfile` before pack or publish from a fresh clone.
- Added no-mistakes evidence for the npm pack dry run and built-CLI update E2E verification.

## Risk Assessment

✅ Low: Docs-only changes are narrow, align with the update command behavior and packaging workflow, and introduce no material merge risk.

## Testing

Inspected the focused README/CONTRIBUTING diff, installed dependencies with the documented frozen pnpm command, ran the relevant Vitest command, verified manual packaging through `npm pack --dry-run`, and captured a built-CLI transcript showing body append, body replacement, body-file replacement, title replacement, and mutual exclusion validation; all checks passed and transient `node_modules`/`dist` outputs were removed.

- Evidence: [npm pack dry-run](https://github.com/kunchenguid/tasks-axi/blob/1d85096ff77ef73e99179628de8bc9e67aaa43e0/.no-mistakes/evidence/fm/taxi-docs-d8/npm-pack-dry-run.txt)
- Evidence: [update CLI E2E transcript](https://github.com/kunchenguid/tasks-axi/blob/1d85096ff77ef73e99179628de8bc9e67aaa43e0/.no-mistakes/evidence/fm/taxi-docs-d8/update-e2e-transcript.txt)
- Evidence: [final scratch backlog](https://github.com/kunchenguid/tasks-axi/blob/1d85096ff77ef73e99179628de8bc9e67aaa43e0/.no-mistakes/evidence/fm/taxi-docs-d8/update-e2e-backlog.md)
- Evidence: [body-file input](https://github.com/kunchenguid/tasks-axi/blob/1d85096ff77ef73e99179628de8bc9e67aaa43e0/.no-mistakes/evidence/fm/taxi-docs-d8/update-body-file-notes.md)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `git diff b5c4442944ec0b79cb8a3999b0bde1934698f013..cd75c7263285bb0e802b04500c13d933ac7f5950 -- README.md CONTRIBUTING.md`
- <code>`pnpm install --frozen-lockfile` from the isolated worktree with no existing `node_modules`</code>
- `pnpm test -- test/commands/crud.test.ts test/backends/markdown.test.ts`
- `npm pack --dry-run 2>&1 | tee .no-mistakes/evidence/fm/taxi-docs-d8/npm-pack-dry-run.txt`
- <code>Manual built-CLI E2E with `TASKS_AXI_FILE=.no-mistakes/evidence/fm/taxi-docs-d8/update-e2e-backlog.md node dist/bin/tasks-axi.js`: `update --help`, `add ... --body`, `update ... --append`, `update ... --body`, `update ... --body-file`, `update ... --title`, `show ... --full`, and the expected `--body` plus `--body-file` validation error</code>
- <code>`rm -rf node_modules dist` followed by `git status --short` and `find . -maxdepth 2 -type d \( -name node_modules -o -name dist \) -print` to remove transient install/build outputs while preserving evidence</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
