### PR TITLE
feat(cli): add confirmation-forward mutation output

### DIFF
--- a/.no-mistakes/evidence/fm/tasks-axi-confirm-w5/cli-mutation-transcript.txt
+++ b/.no-mistakes/evidence/fm/tasks-axi-confirm-w5/cli-mutation-transcript.txt
@@ -1,0 +1,203 @@
+tasks-axi mutation-output E2E evidence
+backlog: .no-mistakes/evidence/fm/tasks-axi-confirm-w5/e2e-backlog.md
+
+$ pnpm --silent dev add grok-harness-g7 confirm\ mutation\ output --kind ship --repo firstmate --start --file .no-mistakes/evidence/fm/tasks-axi-confirm-w5/e2e-backlog.md
+ok: added grok-harness-g7 (ship, repo firstmate) -> In flight
+task:
+  id: grok-harness-g7
+  title: confirm mutation output
+  state: in_flight
+  blocked: no
+  blocked_by: none
+  kind: ship
+  repo: firstmate
+  priority: "-"
+  created: 2026-06-29
+  closed: "-"
+  deps: none
+  links: none
+  body: ""
+help[2]:
+  - Run `tasks-axi done grok-harness-g7 --pr <url> --file=.no-mistakes/evidence/fm/tasks-axi-confirm-w5/e2e-backlog.md` when it ships
+  - Run `tasks-axi block grok-harness-g7 --by <other> --file=.no-mistakes/evidence/fm/tasks-axi-confirm-w5/e2e-backlog.md` to record a dependency
+
+$ pnpm --silent dev done grok-harness-g7 --pr https://github.com/kunchenguid/tasks-axi/pull/123 --no-prune --file .no-mistakes/evidence/fm/tasks-axi-confirm-w5/e2e-backlog.md
+ok: done grok-harness-g7 -> Done (pr https://github.com/kunchenguid/tasks-axi/pull/123)
+help[1]:
+  - Run `tasks-axi ready --file=.no-mistakes/evidence/fm/tasks-axi-confirm-w5/e2e-backlog.md` to dispatch work unblocked by this
+
+$ pnpm --silent dev add queued-next-q1 queued\ follow-up --repo firstmate --file .no-mistakes/evidence/fm/tasks-axi-confirm-w5/e2e-backlog.md
+ok: added queued-next-q1 (repo firstmate) -> Queued
+task:
+  id: queued-next-q1
+  title: queued follow-up
+  state: queued
+  blocked: no
+  blocked_by: none
+  kind: task
+  repo: firstmate
+  priority: "-"
+  created: 2026-06-29
+  closed: "-"
+  deps: none
+  links: none
+  body: ""
+help[2]:
+  - Run `tasks-axi start queued-next-q1 --file=.no-mistakes/evidence/fm/tasks-axi-confirm-w5/e2e-backlog.md` to move it to in flight
+  - Run `tasks-axi block queued-next-q1 --by <other> --file=.no-mistakes/evidence/fm/tasks-axi-confirm-w5/e2e-backlog.md` to record a dependency
+
+$ pnpm --silent dev start queued-next-q1 --file .no-mistakes/evidence/fm/tasks-axi-confirm-w5/e2e-backlog.md
+ok: start queued-next-q1 -> In flight
+help[1]:
+  - Run `tasks-axi done queued-next-q1 --pr <url> --file=.no-mistakes/evidence/fm/tasks-axi-confirm-w5/e2e-backlog.md` when it ships
+
+$ pnpm --silent dev block queued-next-q1 --by fix-login-k3 --file .no-mistakes/evidence/fm/tasks-axi-confirm-w5/e2e-backlog.md
+ok: block queued-next-q1 -> blocked-by fix-login-k3
+help[2]:
+  - Run `tasks-axi unblock queued-next-q1 --by <other> --file=.no-mistakes/evidence/fm/tasks-axi-confirm-w5/e2e-backlog.md` to clear it
+  - Run `tasks-axi ready --file=.no-mistakes/evidence/fm/tasks-axi-confirm-w5/e2e-backlog.md` to see what is still dispatchable
+
+$ pnpm --silent dev unblock queued-next-q1 --by fix-login-k3 --file .no-mistakes/evidence/fm/tasks-axi-confirm-w5/e2e-backlog.md
+ok: unblock queued-next-q1 -> cleared fix-login-k3
+help[1]:
+  - Run `tasks-axi ready --file=.no-mistakes/evidence/fm/tasks-axi-confirm-w5/e2e-backlog.md` to see newly unblocked work
+
+$ pnpm --silent dev update queued-next-q1 --title renamed\ follow-up --append Evidence\ note\ added\ through\ update. --file .no-mistakes/evidence/fm/tasks-axi-confirm-w5/e2e-backlog.md
+ok: updated queued-next-q1 (title, note)
+task:
+  id: queued-next-q1
+  title: renamed follow-up
+  state: in_flight
+  blocked: no
+  blocked_by: none
+  kind: task
+  repo: firstmate
+  priority: "-"
+  created: 2026-06-29
+  closed: "-"
+  deps: none
+  links: none
+  body: Evidence note added through update.
+help[1]:
+  - Run `tasks-axi show queued-next-q1 --full --file=.no-mistakes/evidence/fm/tasks-axi-confirm-w5/e2e-backlog.md` to see the result
+
+$ pnpm --silent dev reopen grok-harness-g7 --file .no-mistakes/evidence/fm/tasks-axi-confirm-w5/e2e-backlog.md
+ok: reopen grok-harness-g7 -> Queued
+help[1]:
+  - Run `tasks-axi start grok-harness-g7 --file=.no-mistakes/evidence/fm/tasks-axi-confirm-w5/e2e-backlog.md` to move it to in flight
+
+$ pnpm --silent dev rm queued-next-q1 --file .no-mistakes/evidence/fm/tasks-axi-confirm-w5/e2e-backlog.md
+ok: removed queued-next-q1
+help[1]:
+  - Run `tasks-axi list --file=.no-mistakes/evidence/fm/tasks-axi-confirm-w5/e2e-backlog.md` to see remaining tasks
+
+$ pnpm --silent dev add move-me-q1 move\ candidate --file .no-mistakes/evidence/fm/tasks-axi-confirm-w5/e2e-backlog.md
+ok: added move-me-q1 -> Queued
+task:
+  id: move-me-q1
+  title: move candidate
+  state: queued
+  blocked: no
+  blocked_by: none
+  kind: task
+  repo: "-"
+  priority: "-"
+  created: 2026-06-29
+  closed: "-"
+  deps: none
+  links: none
+  body: ""
+help[2]:
+  - Run `tasks-axi start move-me-q1 --file=.no-mistakes/evidence/fm/tasks-axi-confirm-w5/e2e-backlog.md` to move it to in flight
+  - Run `tasks-axi block move-me-q1 --by <other> --file=.no-mistakes/evidence/fm/tasks-axi-confirm-w5/e2e-backlog.md` to record a dependency
+
+$ pnpm --silent dev mv move-me-q1 --to .no-mistakes/evidence/fm/tasks-axi-confirm-w5/e2e-destination.md --file .no-mistakes/evidence/fm/tasks-axi-confirm-w5/e2e-backlog.md
+ok: mv move-me-q1 -> /Users/kunchen/.no-mistakes/worktrees/6a0c69bae187/01KWAQXHGJT5N3C63TF37X05YN/.no-mistakes/evidence/fm/tasks-axi-confirm-w5/e2e-destination.md
+help[1]:
+  - Run `tasks-axi list --file=.no-mistakes/evidence/fm/tasks-axi-confirm-w5/e2e-backlog.md` to see remaining tasks
+
+$ pnpm --silent dev add archive-candidate-q1 archive\ candidate --file .no-mistakes/evidence/fm/tasks-axi-confirm-w5/e2e-backlog.md
+ok: added archive-candidate-q1 -> Queued
+task:
+  id: archive-candidate-q1
+  title: archive candidate
+  state: queued
+  blocked: no
+  blocked_by: none
+  kind: task
+  repo: "-"
+  priority: "-"
+  created: 2026-06-29
+  closed: "-"
+  deps: none
+  links: none
+  body: ""
+help[2]:
+  - Run `tasks-axi start archive-candidate-q1 --file=.no-mistakes/evidence/fm/tasks-axi-confirm-w5/e2e-backlog.md` to move it to in flight
+  - Run `tasks-axi block archive-candidate-q1 --by <other> --file=.no-mistakes/evidence/fm/tasks-axi-confirm-w5/e2e-backlog.md` to record a dependency
+
+$ pnpm --silent dev done archive-candidate-q1 --no-prune --file .no-mistakes/evidence/fm/tasks-axi-confirm-w5/e2e-backlog.md
+ok: done archive-candidate-q1 -> Done
+help[1]:
+  - Run `tasks-axi ready --file=.no-mistakes/evidence/fm/tasks-axi-confirm-w5/e2e-backlog.md` to dispatch work unblocked by this
+
+$ pnpm --silent dev prune --keep 1 --file .no-mistakes/evidence/fm/tasks-axi-confirm-w5/e2e-backlog.md
+ok: prune done -> archived 1 (kept 1)
+help[1]:
+  - Run `tasks-axi list --state done --file=.no-mistakes/evidence/fm/tasks-axi-confirm-w5/e2e-backlog.md` to see retained Done items
+
+$ pnpm --silent dev render --file .no-mistakes/evidence/fm/tasks-axi-confirm-w5/e2e-backlog.md
+ok: render -> normalized 4
+help[1]:
+  - Run `tasks-axi list --file=.no-mistakes/evidence/fm/tasks-axi-confirm-w5/e2e-backlog.md` to see the normalized backlog
+
+$ pnpm --silent dev add json-q1 machine\ readable\ confirmation --repo firstmate --json --file .no-mistakes/evidence/fm/tasks-axi-confirm-w5/e2e-backlog.md
+{
+  "ok": true,
+  "action": "add",
+  "task": {
+    "id": "json-q1",
+    "title": "machine readable confirmation",
+    "state": "queued",
+    "kind": null,
+    "repo": "firstmate",
+    "priority": null,
+    "created": "2026-06-29",
+    "closed": null,
+    "deps": [],
+    "links": [],
+    "body": null,
+    "blocked": false,
+    "blocked_by": []
+  }
+}
+
+$ sed -n 1\,220p .no-mistakes/evidence/fm/tasks-axi-confirm-w5/e2e-backlog.md
+# Backlog
+
+## In flight
+- [ ] fix-login-k3 - one line (repo: app, since 2026-06-20)
+
+## Queued
+- [ ] add-tests-q7 - one line (repo: app) blocked-by: fix-login-k3 - waits on the login refactor
+- [ ] grok-harness-g7 - confirm mutation output https://github.com/kunchenguid/tasks-axi/pull/123 (repo: firstmate) (kind: ship)
+- [ ] json-q1 - machine readable confirmation (repo: firstmate) (since 2026-06-29)
+
+## Done
+- [x] archive-candidate-q1 - archive candidate (done 2026-06-29)
+
+$ sed -n 1\,220p .no-mistakes/evidence/fm/tasks-axi-confirm-w5/e2e-destination.md
+# Backlog
+
+## In flight
+
+## Queued
+- [ ] move-me-q1 - move candidate (since 2026-06-29)
+
+## Done
+
+$ sed -n 1\,220p .no-mistakes/evidence/fm/tasks-axi-confirm-w5/done-archive.md
+
+## Archived 2026-06-29
+- [x] legacy-done-z1 - one line - https://github.com/o/r/pull/12 (merged 2026-06-21)
+

--- a/.no-mistakes/evidence/fm/tasks-axi-confirm-w5/done-archive.md
+++ b/.no-mistakes/evidence/fm/tasks-axi-confirm-w5/done-archive.md
@@ -1,0 +1,3 @@
+
+## Archived 2026-06-29
+- [x] legacy-done-z1 - one line - https://github.com/o/r/pull/12 (merged 2026-06-21)

--- a/.no-mistakes/evidence/fm/tasks-axi-confirm-w5/e2e-backlog.md
+++ b/.no-mistakes/evidence/fm/tasks-axi-confirm-w5/e2e-backlog.md
@@ -1,0 +1,12 @@
+# Backlog
+
+## In flight
+- [ ] fix-login-k3 - one line (repo: app, since 2026-06-20)
+
+## Queued
+- [ ] add-tests-q7 - one line (repo: app) blocked-by: fix-login-k3 - waits on the login refactor
+- [ ] grok-harness-g7 - confirm mutation output https://github.com/kunchenguid/tasks-axi/pull/123 (repo: firstmate) (kind: ship)
+- [ ] json-q1 - machine readable confirmation (repo: firstmate) (since 2026-06-29)
+
+## Done
+- [x] archive-candidate-q1 - archive candidate (done 2026-06-29)

--- a/.no-mistakes/evidence/fm/tasks-axi-confirm-w5/e2e-destination.md
+++ b/.no-mistakes/evidence/fm/tasks-axi-confirm-w5/e2e-destination.md
@@ -1,0 +1,8 @@
+# Backlog
+
+## In flight
+
+## Queued
+- [ ] move-me-q1 - move candidate (since 2026-06-29)
+
+## Done

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ The CLI layer never knows which backend is active — it only talks to the `Stor
 - `src/model.ts` — the `Task` data model (report §5).
 - `src/derive.ts` — `blocked` / `ready` are derived in the CLI from `list` + the dep graph, never a Store method, so every backend gets them for free.
 - `src/backends/markdown*.ts` — the only P1 backend.
-- `src/commands/*` — one file per verb group; `src/view.ts` owns the TOON projection.
+- `src/commands/*` — one file per verb group; `src/view.ts` owns the read-side TOON projection; `src/confirm.ts` owns the write-side output (the `ok:` confirmation line, the `--json` payload, and `renderMutation`, which assembles both).
 - Shared helpers copied from the family: `args.ts`, `body.ts`, `format.ts`, `fields.ts`, `toon.ts`, `suggestions.ts`, `skill.ts`.
 
 ## Markdown grammar invariants (the hard part — do not regress)
@@ -42,6 +42,9 @@ The CLI layer never knows which backend is active — it only talks to the `Stor
 - **Dependency mutations validate targets.** `add --blocked-by` and `block --by` reject missing blockers and self-blocks. Parsed dangling blockers are still treated as resolved for legacy hand-edited files.
 - **Blocking tasks are protected.** `rm` and `mv` reject a task that still blocks active dependents; unblock or complete the dependents first.
 - Idempotent mutations exit 0 with `already: true`; errors are `AxiError` with SDK exit codes (VALIDATION_ERROR→2, else 1).
+- **Write ops are confirmation-forward.** Every mutation (`add`/`start`/`done`/`reopen`/`update`/`rm`/`block`/`unblock`/`mv`/`prune`/`render`) leads with a terse `ok: <verb> <id> ... -> <Resulting State>` line (built in `confirm.ts`), then optional structured detail (`add`/`update` keep the full `task:` record), then state-aware hints. The `ok:` line is a plain top-level TOON scalar (no `encode()` quoting) - confirmation messages are built from bounded values (ids, names, validated urls/paths, counts) so the combined output still decodes as TOON.
+- **Hints are state-aware, never contradictory.** A command must not suggest an action it just performed. `add` branches its suggestion on the resulting state (`getSuggestions({action:"add", state})`): `--start`/in-flight → suggest `done`, queued → suggest `start`, done → suggest `reopen`. This killed the `add --start` → "run start" bug. Idempotent paths emit the same state-aware hint as the fresh path.
+- **`--json` is the machine-readable success signal.** Every mutation accepts `--json`, which replaces the TOON output with a single pretty-printed object `{ ok: true, action, [already], task|id|..., ... }` (see `renderMutation` / `taskToJson`). Lets an agent confirm a write deterministically without a follow-up read. Errors still use structured-error output + non-zero exit (not JSON), so `exit 0` + `ok:true` = success.
 
 ## Build / test / ship
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,9 +42,16 @@ The CLI layer never knows which backend is active — it only talks to the `Stor
 - **Dependency mutations validate targets.** `add --blocked-by` and `block --by` reject missing blockers and self-blocks. Parsed dangling blockers are still treated as resolved for legacy hand-edited files.
 - **Blocking tasks are protected.** `rm` and `mv` reject a task that still blocks active dependents; unblock or complete the dependents first.
 - Idempotent mutations exit 0 with `already: true`; errors are `AxiError` with SDK exit codes (VALIDATION_ERROR→2, else 1).
-- **Write ops are confirmation-forward.** Every mutation (`add`/`start`/`done`/`reopen`/`update`/`rm`/`block`/`unblock`/`mv`/`prune`/`render`) leads with a terse `ok: <verb> <id> ... -> <Resulting State>` line (built in `confirm.ts`), then optional structured detail (`add`/`update` keep the full `task:` record), then state-aware hints. The `ok:` line is a plain top-level TOON scalar (no `encode()` quoting) - confirmation messages are built from bounded values (ids, names, validated urls/paths, counts) so the combined output still decodes as TOON.
-- **Hints are state-aware, never contradictory.** A command must not suggest an action it just performed. `add` branches its suggestion on the resulting state (`getSuggestions({action:"add", state})`): `--start`/in-flight → suggest `done`, queued → suggest `start`, done → suggest `reopen`. This killed the `add --start` → "run start" bug. Idempotent paths emit the same state-aware hint as the fresh path.
-- **`--json` is the machine-readable success signal.** Every mutation accepts `--json`, which replaces the TOON output with a single pretty-printed object `{ ok: true, action, [already], task|id|..., ... }` (see `renderMutation` / `taskToJson`). Lets an agent confirm a write deterministically without a follow-up read. Errors still use structured-error output + non-zero exit (not JSON), so `exit 0` + `ok:true` = success.
+- **Write ops are confirmation-forward.** Every mutation (`add`/`start`/`done`/`reopen`/`update`/`rm`/`block`/`unblock`/`mv`/`prune`/`render`) leads with a terse `ok:` line (built in `confirm.ts`) confirming the write result.
+  Task-state mutations include the resulting state (e.g. `ok: start <id> -> In flight`), while maintenance/removal commands confirm their own result shape (e.g. `ok: render -> normalized <n>`, `ok: removed <id>`).
+  Optional structured detail follows (`add`/`update` keep the full `task:` record), then state-aware hints.
+  The `ok:` line is a plain top-level TOON scalar (no `encode()` quoting) - confirmation messages are built from bounded values (ids, names, validated urls/paths, counts) so the combined output still decodes as TOON.
+- **Hints are state-aware, never contradictory.** A command must not suggest an action it just performed.
+  `add` branches its suggestion on the resulting state (`getSuggestions({action:"add", state})`): `--start`/in-flight → suggest `done`, queued → suggest `start`, done → suggest `reopen`.
+  Idempotent paths emit the same state-aware hint as the fresh path.
+- **`--json` is the machine-readable success signal.** Every mutation accepts `--json`, which replaces the TOON output with a single pretty-printed object `{ ok: true, action, [already], task|id|operation fields... }` (see `renderMutation` / `taskToJson`).
+  This lets an agent confirm a write deterministically without a follow-up read.
+  Errors still use structured-error output + non-zero exit (not JSON), so `exit 0` + `ok:true` = success.
 
 ## Build / test / ship
 

--- a/README.md
+++ b/README.md
@@ -115,8 +115,10 @@ tasks-axi mv hibit-cert-cleanup --to ../homemux/data/backlog.md
 
 Output is [TOON](https://toonformat.dev)-encoded and token-efficient.
 The long task body is truncated by default — the whole point is that `list` stays cheap; use `--full` only when you need the complete notes.
+Every write leads with a terse `ok:` line confirming the resulting state (e.g. `ok: start lavish-share -> In flight`, `ok: done grok-harness-g7 -> Done (pr <url>)`), followed by state-aware next-step hints that never suggest an action the command just performed.
 Mutations are idempotent and report what changed (`already: true` on a no-op), so re-running one is safe.
 Running `done` again on an already Done task can still backfill a new `--pr`, `--report`, or `--note` without changing the original close date.
+Pass `--json` to any mutation for a machine-readable result object (`{ "ok": true, "action": …, "task": { … } }`) instead of TOON, so an agent can confirm a write deterministically without a follow-up read.
 
 Run `tasks-axi --help` for the command list, or `tasks-axi <command> --help` for per-command usage.
 

--- a/README.md
+++ b/README.md
@@ -115,10 +115,10 @@ tasks-axi mv hibit-cert-cleanup --to ../homemux/data/backlog.md
 
 Output is [TOON](https://toonformat.dev)-encoded and token-efficient.
 The long task body is truncated by default — the whole point is that `list` stays cheap; use `--full` only when you need the complete notes.
-Every write leads with a terse `ok:` line confirming the resulting state (e.g. `ok: start lavish-share -> In flight`, `ok: done grok-harness-g7 -> Done (pr <url>)`), followed by state-aware next-step hints that never suggest an action the command just performed.
+Every write leads with a terse `ok:` line confirming the write result, including the resulting task state when the command changes one (e.g. `ok: start lavish-share -> In flight`, `ok: done grok-harness-g7 -> Done (pr <url>)`, `ok: render -> normalized 3`), followed by state-aware next-step hints that never suggest an action the command just performed.
 Mutations are idempotent and report what changed (`already: true` on a no-op), so re-running one is safe.
 Running `done` again on an already Done task can still backfill a new `--pr`, `--report`, or `--note` without changing the original close date.
-Pass `--json` to any mutation for a machine-readable result object (`{ "ok": true, "action": …, "task": { … } }`) instead of TOON, so an agent can confirm a write deterministically without a follow-up read.
+Pass `--json` to any mutation for a machine-readable result object (`{ "ok": true, "action": …, "task": { … } }` or operation-specific result fields) instead of TOON, so an agent can confirm a write deterministically without a follow-up read.
 
 Run `tasks-axi --help` for the command list, or `tasks-axi <command> --help` for per-command usage.
 

--- a/skills/tasks-axi/SKILL.md
+++ b/skills/tasks-axi/SKILL.md
@@ -29,7 +29,8 @@ Use tasks-axi whenever a task touches the backlog: filing or dispatching work, m
 3. The long notes never appear in `list`; run `show <id> --full` to read a task's complete body.
 4. `add` takes a caller-supplied id (the join key), e.g. `tasks-axi add fm-x "title" --kind ship --repo firstmate --start`; or pass `--mint` to generate a slug-xx id from the title.
 5. `done <id> --pr <url>` (or `--report <path>`) closes a task, records the link, and prunes the Done list (archived, never deleted). Then `ready` shows work it unblocked.
-6. Every response ends with contextual next-step hints under `help:` - follow them.
+6. Human-readable responses include contextual next-step hints under `help:` when there is a useful follow-up - follow them.
+7. `--json` mutation responses skip `help:` and return the deterministic result object instead.
 
 ## Commands
 
@@ -42,9 +43,11 @@ Run `npx -y tasks-axi --help` for global flags, or `npx -y tasks-axi <command> -
 
 ## Tips
 
-- Output is TOON-encoded and token-efficient; the long task body is truncated by default - the whole point is that `list` stays cheap. Use `--full` only when you need the complete notes.
-- Every write leads with an `ok:` line confirming the resulting state (e.g. `ok: start <id> -> In flight`, `ok: done <id> -> Done (pr <url>)`), then state-aware next-step hints. Mutations are idempotent and add `already: true` on a no-op; re-running is safe.
-- Pass `--json` to any mutation (`add`, `start`, `done`, `reopen`, `update`, `rm`, `block`, `unblock`, `mv`, `prune`, `render`) for a machine-readable result object (`{ "ok": true, "action": ..., "task": { ... } }`) instead of TOON - confirm a write deterministically without a follow-up read.
+- Output is TOON-encoded and token-efficient; the long task body is truncated by default - the whole point is that `list` stays cheap.
+  Use `--full` only when you need the complete notes.
+- Every write leads with an `ok:` line confirming the write result, including the resulting task state when the command changes one (e.g. `ok: start <id> -> In flight`, `ok: done <id> -> Done (pr <url>)`, `ok: render -> normalized <n>`), then state-aware next-step hints.
+  Mutations are idempotent and add `already: true` on a no-op; re-running is safe.
+- Pass `--json` to any mutation (`add`, `start`, `done`, `reopen`, `update`, `rm`, `block`, `unblock`, `mv`, `prune`, `render`) for a machine-readable result object (`{ "ok": true, "action": ..., "task": { ... } }` or operation-specific result fields) instead of TOON - confirm a write deterministically without a follow-up read.
 - `block <id> --by <other>` and `unblock` manage the dependency graph; `ready` lists only queued work with no unresolved blocker.
 - Filter `list` with `--state`, `--repo`, `--kind`, `--blocked`, `--limit`, and add columns with `--fields a,b,c`.
 - `update <id> --append "<note>"` adds to a task's body; `update <id> --body "<text>"` or `--body-file <path>` replaces it, and `--title "<text>"` replaces the title; `render` normalizes the file; `mv <id> --to <path>` moves a task to another backlog.

--- a/skills/tasks-axi/SKILL.md
+++ b/skills/tasks-axi/SKILL.md
@@ -43,7 +43,8 @@ Run `npx -y tasks-axi --help` for global flags, or `npx -y tasks-axi <command> -
 ## Tips
 
 - Output is TOON-encoded and token-efficient; the long task body is truncated by default - the whole point is that `list` stays cheap. Use `--full` only when you need the complete notes.
-- Mutations are idempotent and report what changed (`already: true` on a no-op); re-running a mutation is safe.
+- Every write leads with an `ok:` line confirming the resulting state (e.g. `ok: start <id> -> In flight`, `ok: done <id> -> Done (pr <url>)`), then state-aware next-step hints. Mutations are idempotent and add `already: true` on a no-op; re-running is safe.
+- Pass `--json` to any mutation (`add`, `start`, `done`, `reopen`, `update`, `rm`, `block`, `unblock`, `mv`, `prune`, `render`) for a machine-readable result object (`{ "ok": true, "action": ..., "task": { ... } }`) instead of TOON - confirm a write deterministically without a follow-up read.
 - `block <id> --by <other>` and `unblock` manage the dependency graph; `ready` lists only queued work with no unresolved blocker.
 - Filter `list` with `--state`, `--repo`, `--kind`, `--blocked`, `--limit`, and add columns with `--fields a,b,c`.
 - `update <id> --append "<note>"` adds to a task's body; `update <id> --body "<text>"` or `--body-file <path>` replaces it, and `--title "<text>"` replaces the title; `render` normalizes the file; `mv <id> --to <path>` moves a task to another backlog.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -57,8 +57,8 @@ type MainOptions = {
 export const TOP_HELP = `usage: tasks-axi [command] [args] [flags]
 commands[16]:
   (none)=dashboard, add, list, show, start, done, reopen, update, rm, block, unblock, ready, mv, prune, render, setup
-flags[3]:
-  --backend <name> (after command), --file <path> (after command), --help, -v/-V/--version
+flags[4]:
+  --backend <name> (after command), --file <path> (after command), --json (mutations: machine-readable result), --help, -v/-V/--version
 examples:
   tasks-axi
   tasks-axi add homemux-h7 "owns HomeMux end to end" --kind secondmate --start

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,7 +2,10 @@ import { existsSync, readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { runAxiCli } from "axi-sdk-js";
-import { requireFlagValue, requireNonEmptySingleLineFlagValue } from "./args.js";
+import {
+  requireFlagValue,
+  requireNonEmptySingleLineFlagValue,
+} from "./args.js";
 import { resolveTasksContext, type TasksContext } from "./context.js";
 import {
   ADD_HELP,

--- a/src/commands/crud.ts
+++ b/src/commands/crud.ts
@@ -11,6 +11,11 @@ import {
 } from "../args.js";
 import { takeBody } from "../body.js";
 import { deriveLinks, extractTags } from "../backends/markdown-grammar.js";
+import {
+  renderMutation,
+  stateLabel,
+  taskToJson,
+} from "../confirm.js";
 import { requireCtx, type TasksContext } from "../context.js";
 import { blockedIds } from "../derive.js";
 import { AxiError, notFound } from "../errors.js";
@@ -41,6 +46,7 @@ flags:
   --start (place in In flight) | --queue (place in Queued, default)
   --blocked-by <id> (repeatable, must exist), --pr <url>, --report <path>, --priority <0-4>
   --mint [--prefix <p>]   mint a slug-xx id from the title instead of passing one
+  --json   print the resulting task as a JSON object
 examples:
   tasks-axi add lavish-foo-q9 "fix summary toggle" --kind ship --repo lavish-axi --start
   tasks-axi add fm-x "adopt lease" --blocked-by treehouse-lease-t4
@@ -68,6 +74,7 @@ aliases: edit
 flags:
   --title <text>, --body <text> or --body-file <path>, --append "<note>"
   --repo <name>, --kind <name>, --priority <0-4>, --pr <url>, --report <path>
+  --json   print the resulting task as a JSON object
 examples:
   tasks-axi update nm-release-validation --append "step 3 in progress on lavish #87"
   tasks-axi update fm-x --repo firstmate --kind ship`;
@@ -75,6 +82,8 @@ examples:
 export const RM_HELP = `usage: tasks-axi rm <id>
 aliases: delete
 Fails while active tasks still block on this id.
+flags:
+  --json   print the result as a JSON object
 examples:
   tasks-axi rm stale-task-q1`;
 
@@ -207,6 +216,7 @@ export async function addCommand(
   const report = takeFlag(args, "--report");
   const priority = parsePriority(takeFlag(args, "--priority"));
   const deps = parseDeps(args);
+  const json = takeBoolFlag(args, "--json");
   const start = takeBoolFlag(args, "--start");
   const queue = takeBoolFlag(args, "--queue");
   const mint = takeBoolFlag(args, "--mint");
@@ -257,11 +267,24 @@ export async function addCommand(
     const existing = await store.get(id);
     if (existing) {
       const all = (await store.list({})).items;
-      const blocks = [
-        "already: true",
-        renderTaskDetail(existing, all, false, showFullTextHint(existing)),
-      ];
-      return renderOutput(blocks);
+      return renderMutation({
+        json,
+        confirm: `add ${id} already exists -> ${stateLabel(existing.state)}`,
+        already: true,
+        jsonPayload: {
+          ok: true,
+          action: "add",
+          already: true,
+          task: taskToJson(existing, all),
+        },
+        detail: renderTaskDetail(existing, all, false, showFullTextHint(existing)),
+        suggestions: getSuggestions({
+          action: "add",
+          id,
+          state: existing.state,
+          globals: context?.suggestionGlobals,
+        }),
+      });
     }
   }
 
@@ -280,17 +303,26 @@ export async function addCommand(
 
   const task = await store.create(input);
   const all = (await store.list({})).items;
-  const blocks = [
-    renderTaskDetail(task, all, false, showFullTextHint(task)),
-    renderHelp(
-      getSuggestions({
-        action: "add",
-        id,
-        globals: context?.suggestionGlobals,
-      }),
-    ),
-  ];
-  return renderOutput(blocks);
+  return renderMutation({
+    json,
+    confirm: `added ${id}${addAttrs(task)} -> ${stateLabel(task.state)}`,
+    jsonPayload: { ok: true, action: "add", task: taskToJson(task, all) },
+    detail: renderTaskDetail(task, all, false, showFullTextHint(task)),
+    suggestions: getSuggestions({
+      action: "add",
+      id,
+      state: task.state,
+      globals: context?.suggestionGlobals,
+    }),
+  });
+}
+
+/** The `(kind, repo X)` parenthetical for an add confirmation, omitted when bare. */
+function addAttrs(task: { kind?: string; repo?: string }): string {
+  const parts: string[] = [];
+  if (task.kind) parts.push(task.kind);
+  if (task.repo) parts.push(`repo ${task.repo}`);
+  return parts.length > 0 ? ` (${parts.join(", ")})` : "";
 }
 
 export async function listCommand(
@@ -418,6 +450,7 @@ export async function updateCommand(
   const { store } = requireCtx(context);
   const args = [...rawArgs];
 
+  const json = takeBoolFlag(args, "--json");
   const title = takeFlag(args, "--title");
   const body = takeBody(args);
   const append = takeFlag(args, "--append");
@@ -475,17 +508,38 @@ export async function updateCommand(
   }
   const task = await store.update(id, patch);
   const all = (await store.list({})).items;
-  const blocks = [
-    renderTaskDetail(task, all, false, showFullTextHint(task)),
-    renderHelp(
-      getSuggestions({
-        action: "update",
-        id,
-        globals: context?.suggestionGlobals,
-      }),
-    ),
+  return renderMutation({
+    json,
+    confirm: `updated ${id} (${changedFields(patch).join(", ")})`,
+    jsonPayload: {
+      ok: true,
+      action: "update",
+      changed: changedFields(patch),
+      task: taskToJson(task, all),
+    },
+    detail: renderTaskDetail(task, all, false, showFullTextHint(task)),
+    suggestions: getSuggestions({
+      action: "update",
+      id,
+      globals: context?.suggestionGlobals,
+    }),
+  });
+}
+
+/** Friendly names of the fields a patch touched, for the update confirmation. */
+function changedFields(patch: TaskPatch): string[] {
+  const labels: Array<[keyof TaskPatch, string]> = [
+    ["title", "title"],
+    ["body", "body"],
+    ["appendBody", "note"],
+    ["repo", "repo"],
+    ["kind", "kind"],
+    ["priority", "priority"],
+    ["addLinks", "links"],
   ];
-  return renderOutput(blocks);
+  return labels
+    .filter(([key]) => patch[key] !== undefined)
+    .map(([, label]) => label);
 }
 
 export async function rmCommand(
@@ -493,12 +547,9 @@ export async function rmCommand(
   context?: TasksContext,
 ): Promise<string> {
   const { store } = requireCtx(context);
-  const positionals = requirePositionals(
-    [...rawArgs],
-    1,
-    1,
-    RM_HELP.split("\n")[0],
-  );
+  const args = [...rawArgs];
+  const json = takeBoolFlag(args, "--json");
+  const positionals = requirePositionals(args, 1, 1, RM_HELP.split("\n")[0]);
   const id = requireId(positionals[0], "id");
 
   if (!(await store.get(id))) {
@@ -506,15 +557,14 @@ export async function rmCommand(
   }
   await store.remove(id);
 
-  const blocks = [
-    `removed:\n  id: ${id}`,
-    renderHelp(
-      getSuggestions({
-        action: "rm",
-        id,
-        globals: context?.suggestionGlobals,
-      }),
-    ),
-  ];
-  return renderOutput(blocks);
+  return renderMutation({
+    json,
+    confirm: `removed ${id}`,
+    jsonPayload: { ok: true, action: "rm", id, removed: true },
+    suggestions: getSuggestions({
+      action: "rm",
+      id,
+      globals: context?.suggestionGlobals,
+    }),
+  });
 }

--- a/src/commands/crud.ts
+++ b/src/commands/crud.ts
@@ -11,11 +11,7 @@ import {
 } from "../args.js";
 import { takeBody } from "../body.js";
 import { deriveLinks, extractTags } from "../backends/markdown-grammar.js";
-import {
-  renderMutation,
-  stateLabel,
-  taskToJson,
-} from "../confirm.js";
+import { renderMutation, stateLabel, taskToJson } from "../confirm.js";
 import { requireCtx, type TasksContext } from "../context.js";
 import { blockedIds } from "../derive.js";
 import { AxiError, notFound } from "../errors.js";
@@ -94,7 +90,10 @@ function parseDeps(args: string[]): Dep[] {
   }));
 }
 
-async function requireExistingBlockers(store: Store, deps: Dep[]): Promise<void> {
+async function requireExistingBlockers(
+  store: Store,
+  deps: Dep[],
+): Promise<void> {
   for (const dep of deps) {
     if (dep.type !== "blocked-by") continue;
     if (await store.get(dep.id)) continue;
@@ -111,9 +110,11 @@ function requireSafeTagFlagValue(
   const checked = requireNonEmptySingleLineFlagValue(flag, value);
   if (checked === undefined) return undefined;
   if (/[()]/.test(checked)) {
-    throw new AxiError(`${flag} must not contain parentheses`, "VALIDATION_ERROR", [
-      `Pass ${flag}=... without parentheses`,
-    ]);
+    throw new AxiError(
+      `${flag} must not contain parentheses`,
+      "VALIDATION_ERROR",
+      [`Pass ${flag}=... without parentheses`],
+    );
   }
   return checked.trim();
 }
@@ -131,7 +132,9 @@ function requireTypedLinkUrl(
     ]);
   }
   const url = checked.trim();
-  if (!deriveLinks(url).some((link) => link.kind === kind && link.url === url)) {
+  if (
+    !deriveLinks(url).some((link) => link.kind === kind && link.url === url)
+  ) {
     const expected =
       kind === "pr"
         ? "an http(s) pull request URL ending in /pull/<number>"
@@ -160,7 +163,11 @@ function parsePriority(raw: string | undefined): number | undefined {
   return Number(raw);
 }
 
-function requireTitle(raw: string, message: string, suggestion: string): string {
+function requireTitle(
+  raw: string,
+  message: string,
+  suggestion: string,
+): string {
   if (/[\r\n]/.test(raw)) {
     throw new AxiError("Task title must be a single line", "VALIDATION_ERROR");
   }
@@ -203,14 +210,8 @@ export async function addCommand(
   const { store } = requireCtx(context);
   const args = [...rawArgs];
 
-  const kind = requireSafeTagFlagValue(
-    "--kind",
-    takeFlag(args, "--kind"),
-  );
-  const repo = requireSafeTagFlagValue(
-    "--repo",
-    takeFlag(args, "--repo"),
-  );
+  const kind = requireSafeTagFlagValue("--kind", takeFlag(args, "--kind"));
+  const repo = requireSafeTagFlagValue("--repo", takeFlag(args, "--repo"));
   const body = requireNonEmptyFlagValue("--body", takeBody(args));
   const pr = takeFlag(args, "--pr");
   const report = takeFlag(args, "--report");
@@ -224,12 +225,17 @@ export async function addCommand(
   const titleFlag = takeFlag(args, "--title");
 
   if (start && queue) {
-    throw new AxiError("Use only one of --start or --queue", "VALIDATION_ERROR");
+    throw new AxiError(
+      "Use only one of --start or --queue",
+      "VALIDATION_ERROR",
+    );
   }
   if (rawPrefix !== undefined && !mint) {
-    throw new AxiError("--prefix can only be used with --mint", "VALIDATION_ERROR", [
-      'Run `tasks-axi add "<title>" --mint --prefix <p>`, or omit --prefix',
-    ]);
+    throw new AxiError(
+      "--prefix can only be used with --mint",
+      "VALIDATION_ERROR",
+      ['Run `tasks-axi add "<title>" --mint --prefix <p>`, or omit --prefix'],
+    );
   }
   const prefix = requireNonEmptySingleLineFlagValue("--prefix", rawPrefix);
 
@@ -277,7 +283,12 @@ export async function addCommand(
           already: true,
           task: taskToJson(existing, all),
         },
-        detail: renderTaskDetail(existing, all, false, showFullTextHint(existing)),
+        detail: renderTaskDetail(
+          existing,
+          all,
+          false,
+          showFullTextHint(existing),
+        ),
         suggestions: getSuggestions({
           action: "add",
           id,

--- a/src/commands/maintain.ts
+++ b/src/commands/maintain.ts
@@ -2,24 +2,28 @@ import {
   parseNonNegativeIntegerFlag,
   parseStateFlag,
   requirePositionals,
+  takeBoolFlag,
   takeFlag,
 } from "../args.js";
+import { renderMutation } from "../confirm.js";
 import { requireCtx, type TasksContext } from "../context.js";
 import { unsupported } from "../errors.js";
 import { getSuggestions } from "../suggestions.js";
-import { field, renderDetail, renderHelp, renderOutput } from "../toon.js";
 
 export const PRUNE_HELP = `usage: tasks-axi prune [--keep <n>] [--state done]
 Trim a section to the N most recent tasks, archiving the rest (never deletes).
 flags:
   --keep <n>   tasks to retain (default from config, usually 10)
   --state <queued|in_flight|done>   section to prune (default done)
+  --json   print the result as a JSON object
 examples:
   tasks-axi prune --keep 10`;
 
 export const RENDER_HELP = `usage: tasks-axi render
 Normalize the backlog file: rewrite every id'd task in canonical form.
-Free-form lines are left untouched.`;
+Free-form lines are left untouched.
+flags:
+  --json   print the result as a JSON object`;
 
 export async function pruneCommand(
   rawArgs: string[],
@@ -28,6 +32,7 @@ export async function pruneCommand(
   const { store, config } = requireCtx(context);
   const args = [...rawArgs];
 
+  const json = takeBoolFlag(args, "--json");
   if (!store.prune) {
     throw unsupported("prune", store.capabilities().backend);
   }
@@ -39,24 +44,22 @@ export async function pruneCommand(
 
   const result = await store.prune({ state, keep, archive: true });
 
-  return renderOutput([
-    renderDetail(
-      "prune",
-      {
-        state,
-        kept: keep,
-        archived: result.archived,
-        ids: result.ids.length > 0 ? result.ids.join(",") : "none",
-      },
-      [field("state"), field("kept"), field("archived"), field("ids")],
-    ),
-    renderHelp(
-      getSuggestions({
-        action: "prune",
-        globals: context?.suggestionGlobals,
-      }),
-    ),
-  ]);
+  return renderMutation({
+    json,
+    confirm: `prune ${state} -> archived ${result.archived} (kept ${keep})`,
+    jsonPayload: {
+      ok: true,
+      action: "prune",
+      state,
+      kept: keep,
+      archived: result.archived,
+      ids: result.ids,
+    },
+    suggestions: getSuggestions({
+      action: "prune",
+      globals: context?.suggestionGlobals,
+    }),
+  });
 }
 
 export async function renderCommand(
@@ -64,12 +67,20 @@ export async function renderCommand(
   context?: TasksContext,
 ): Promise<string> {
   const { store } = requireCtx(context);
-  requirePositionals([...rawArgs], 0, 0, RENDER_HELP.split("\n")[0]);
+  const args = [...rawArgs];
+  const json = takeBoolFlag(args, "--json");
+  requirePositionals(args, 0, 0, RENDER_HELP.split("\n")[0]);
   if (!store.render) {
     throw unsupported("render", store.capabilities().backend);
   }
   const count = await store.render();
-  return renderOutput([
-    renderDetail("render", { normalized: count }, [field("normalized")]),
-  ]);
+  return renderMutation({
+    json,
+    confirm: `render -> normalized ${count}`,
+    jsonPayload: { ok: true, action: "render", normalized: count },
+    suggestions: getSuggestions({
+      action: "render",
+      globals: context?.suggestionGlobals,
+    }),
+  });
 }

--- a/src/commands/state.ts
+++ b/src/commands/state.ts
@@ -10,6 +10,11 @@ import {
   takeBoolFlag,
   takeFlag,
 } from "../args.js";
+import {
+  renderMutation,
+  stateLabel,
+  taskToJson,
+} from "../confirm.js";
 import { requireCtx, type TasksContext } from "../context.js";
 import { readyTasks } from "../derive.js";
 import { AxiError, notFound } from "../errors.js";
@@ -18,11 +23,13 @@ import { validateDependencyId } from "../id.js";
 import type { Dep, Task, TaskInput, TaskLink, TaskPatch } from "../model.js";
 import type { Store } from "../store.js";
 import { getSuggestions } from "../suggestions.js";
-import { field, renderDetail, renderHelp, renderOutput } from "../toon.js";
+import { renderHelp, renderOutput } from "../toon.js";
 import { renderTaskDetail, renderTaskList, showFullTextHint } from "../view.js";
 
 export const START_HELP = `usage: tasks-axi start <id>
 Move a task to In flight (idempotent).
+flags:
+  --json   print the resulting task as a JSON object
 examples:
   tasks-axi start firstmate-treehouse-lease-adopt`;
 
@@ -32,21 +39,28 @@ Re-running on an already Done task backfills links/notes without changing the cl
 flags:
   --pr <url>, --report <path>, --note "<text>"
   --keep <n> (default from config), --no-prune
+  --json   print the resulting task as a JSON object
 examples:
   tasks-axi done sm-idle-handoff-q8 --pr https://github.com/o/r/pull/42
   tasks-axi done pr31-review-r6 --report data/pr31-review-r6/report.md`;
 
 export const REOPEN_HELP = `usage: tasks-axi reopen <id>
-Move a Done/In flight task back to Queued (idempotent).`;
+Move a Done/In flight task back to Queued (idempotent).
+flags:
+  --json   print the resulting task as a JSON object`;
 
 export const BLOCK_HELP = `usage: tasks-axi block <id> --by <other>
 Record a blocked-by dependency edge (idempotent).
 The blocker named by --by must already exist.
+flags:
+  --json   print the resulting task as a JSON object
 examples:
   tasks-axi block firstmate-treehouse-lease-adopt --by treehouse-lease-t4`;
 
 export const UNBLOCK_HELP = `usage: tasks-axi unblock <id> --by <other>
-Clear a blocked-by dependency edge (idempotent).`;
+Clear a blocked-by dependency edge (idempotent).
+flags:
+  --json   print the resulting task as a JSON object`;
 
 export const READY_HELP = `usage: tasks-axi ready [--repo <name>]
 List unblocked queued work - the tasks dispatchable right now.`;
@@ -54,6 +68,8 @@ List unblocked queued work - the tasks dispatchable right now.`;
 export const MV_HELP = `usage: tasks-axi mv <id> --to <path-or-dir>
 Move a task to another backlog file (generalizes a hand-rolled line move).
 Fails while active tasks still block on this id.
+flags:
+  --json   print the result as a JSON object
 examples:
   tasks-axi mv hibit-cert-cleanup --to ../homemux/data/backlog.md`;
 
@@ -62,41 +78,36 @@ export async function startCommand(
   context?: TasksContext,
 ): Promise<string> {
   const { store } = requireCtx(context);
-  const positionals = requirePositionals(
-    [...rawArgs],
-    1,
-    1,
-    START_HELP.split("\n")[0],
-  );
+  const args = [...rawArgs];
+  const json = takeBoolFlag(args, "--json");
+  const positionals = requirePositionals(args, 1, 1, START_HELP.split("\n")[0]);
   const id = requireId(positionals[0], "id");
 
   const current = await store.get(id);
   if (!current) throw notFound(id, { globals: context?.suggestionGlobals });
 
-  if (current.state === "in_flight") {
-    return renderOutput([
-      "already: true",
-      renderDetail("start", { id, state: "in_flight" }, [
-        field("id"),
-        field("state"),
-      ]),
-    ]);
-  }
-
-  const task = await store.transition(id, "in_flight");
-  return renderOutput([
-    renderDetail("start", { id: task.id, state: task.state }, [
-      field("id"),
-      field("state"),
-    ]),
-    renderHelp(
-      getSuggestions({
-        action: "start",
-        id,
-        globals: context?.suggestionGlobals,
-      }),
-    ),
-  ]);
+  const already = current.state === "in_flight";
+  const task = already ? current : await store.transition(id, "in_flight");
+  const all = (await store.list({})).items;
+  return renderMutation({
+    json,
+    confirm: already
+      ? `start ${id} already in flight`
+      : `start ${id} -> ${stateLabel(task.state)}`,
+    already,
+    jsonPayload: {
+      ok: true,
+      action: "start",
+      ...(already ? { already: true } : {}),
+      task: taskToJson(task, all),
+    },
+    suggestions: getSuggestions({
+      action: "start",
+      id,
+      state: task.state,
+      globals: context?.suggestionGlobals,
+    }),
+  });
 }
 
 export async function doneCommand(
@@ -106,6 +117,7 @@ export async function doneCommand(
   const { store, config } = requireCtx(context);
   const args = [...rawArgs];
 
+  const json = takeBoolFlag(args, "--json");
   const pr = requireNonEmptyFlagValue("--pr", takeFlag(args, "--pr"));
   const report = requireNonEmptyFlagValue(
     "--report",
@@ -134,38 +146,63 @@ export async function doneCommand(
       task = await store.update(id, patch);
     }
     const pruned = await pruneDone(store, keep, noPrune);
-    const blocks = [
-      "already: true",
-      renderDetail("done", { id: task.id, state: task.state, pruned }, [
-        field("id"),
-        field("state"),
-        field("pruned"),
-      ]),
-    ];
-    if (hasPatch) {
-      const all = (await store.list({})).items;
-      blocks.push(renderTaskDetail(task, all, false, showFullTextHint(task)));
-    }
-    return renderOutput(blocks);
+    const all = (await store.list({})).items;
+    return renderMutation({
+      json,
+      confirm: `done ${id} already -> ${stateLabel(task.state)}${doneExtras(pr, report)}${prunedNote(pruned)}`,
+      already: true,
+      jsonPayload: {
+        ok: true,
+        action: "done",
+        already: true,
+        pruned,
+        task: taskToJson(task, all),
+      },
+      ...(hasPatch
+        ? { detail: renderTaskDetail(task, all, false, showFullTextHint(task)) }
+        : {}),
+      suggestions: getSuggestions({
+        action: "done",
+        id,
+        state: task.state,
+        globals: context?.suggestionGlobals,
+      }),
+    });
   }
 
   const task = await store.transition(id, "done", opts);
   const pruned = await pruneDone(store, keep, noPrune);
+  const all = (await store.list({})).items;
 
-  return renderOutput([
-    renderDetail("done", { id: task.id, state: task.state, pruned }, [
-      field("id"),
-      field("state"),
-      field("pruned"),
-    ]),
-    renderHelp(
-      getSuggestions({
-        action: "done",
-        id,
-        globals: context?.suggestionGlobals,
-      }),
-    ),
-  ]);
+  return renderMutation({
+    json,
+    confirm: `done ${id} -> ${stateLabel(task.state)}${doneExtras(pr, report)}${prunedNote(pruned)}`,
+    jsonPayload: {
+      ok: true,
+      action: "done",
+      pruned,
+      task: taskToJson(task, all),
+    },
+    suggestions: getSuggestions({
+      action: "done",
+      id,
+      state: task.state,
+      globals: context?.suggestionGlobals,
+    }),
+  });
+}
+
+/** The `(pr X, report Y)` parenthetical for a done confirmation, omitted when bare. */
+function doneExtras(pr: string | undefined, report: string | undefined): string {
+  const parts: string[] = [];
+  if (pr !== undefined) parts.push(`pr ${pr}`);
+  if (report !== undefined) parts.push(`report ${report}`);
+  return parts.length > 0 ? ` (${parts.join(", ")})` : "";
+}
+
+/** A trailing `; pruned N` note, shown only when something was archived. */
+function prunedNote(pruned: number): string {
+  return pruned > 0 ? `; pruned ${pruned}` : "";
 }
 
 async function pruneDone(
@@ -208,41 +245,36 @@ export async function reopenCommand(
   context?: TasksContext,
 ): Promise<string> {
   const { store } = requireCtx(context);
-  const positionals = requirePositionals(
-    [...rawArgs],
-    1,
-    1,
-    REOPEN_HELP.split("\n")[0],
-  );
+  const args = [...rawArgs];
+  const json = takeBoolFlag(args, "--json");
+  const positionals = requirePositionals(args, 1, 1, REOPEN_HELP.split("\n")[0]);
   const id = requireId(positionals[0], "id");
 
   const current = await store.get(id);
   if (!current) throw notFound(id, { globals: context?.suggestionGlobals });
 
-  if (current.state === "queued") {
-    return renderOutput([
-      "already: true",
-      renderDetail("reopen", { id, state: "queued" }, [
-        field("id"),
-        field("state"),
-      ]),
-    ]);
-  }
-
-  const task = await store.transition(id, "queued");
-  return renderOutput([
-    renderDetail("reopen", { id: task.id, state: task.state }, [
-      field("id"),
-      field("state"),
-    ]),
-    renderHelp(
-      getSuggestions({
-        action: "reopen",
-        id,
-        globals: context?.suggestionGlobals,
-      }),
-    ),
-  ]);
+  const already = current.state === "queued";
+  const task = already ? current : await store.transition(id, "queued");
+  const all = (await store.list({})).items;
+  return renderMutation({
+    json,
+    confirm: already
+      ? `reopen ${id} already queued`
+      : `reopen ${id} -> ${stateLabel(task.state)}`,
+    already,
+    jsonPayload: {
+      ok: true,
+      action: "reopen",
+      ...(already ? { already: true } : {}),
+      task: taskToJson(task, all),
+    },
+    suggestions: getSuggestions({
+      action: "reopen",
+      id,
+      state: task.state,
+      globals: context?.suggestionGlobals,
+    }),
+  });
 }
 
 function requireBy(args: string[]): string {
@@ -268,13 +300,13 @@ export async function blockCommand(
 ): Promise<string> {
   const { store } = requireCtx(context);
   const args = [...rawArgs];
+  const json = takeBoolFlag(args, "--json");
   const by = requireBy(args);
   const positionals = requirePositionals(args, 1, 1, BLOCK_HELP.split("\n")[0]);
   const id = requireId(positionals[0], "id");
 
-  if (!(await store.get(id))) {
-    throw notFound(id, { globals: context?.suggestionGlobals });
-  }
+  const current = await store.get(id);
+  if (!current) throw notFound(id, { globals: context?.suggestionGlobals });
   if (by === id) {
     throw new AxiError("A task cannot block itself", "VALIDATION_ERROR");
   }
@@ -282,24 +314,27 @@ export async function blockCommand(
   const dep: Dep = { type: "blocked-by", id: by };
   const added = await store.addDep(id, dep);
 
-  const blocks: string[] = [];
-  if (!added) blocks.push("already: true");
-  blocks.push(
-    renderDetail("block", { id, blocked_by: by }, [
-      field("id"),
-      field("blocked_by"),
-    ]),
-  );
-  blocks.push(
-    renderHelp(
-      getSuggestions({
-        action: "block",
-        id,
-        globals: context?.suggestionGlobals,
-      }),
-    ),
-  );
-  return renderOutput(blocks);
+  const all = (await store.list({})).items;
+  const task = all.find((t) => t.id === id) ?? current;
+  return renderMutation({
+    json,
+    confirm: added
+      ? `block ${id} -> blocked-by ${by}`
+      : `block ${id} already blocked-by ${by}`,
+    already: !added,
+    jsonPayload: {
+      ok: true,
+      action: "block",
+      ...(added ? {} : { already: true }),
+      blocked_by: by,
+      task: taskToJson(task, all),
+    },
+    suggestions: getSuggestions({
+      action: "block",
+      id,
+      globals: context?.suggestionGlobals,
+    }),
+  });
 }
 
 export async function unblockCommand(
@@ -308,6 +343,7 @@ export async function unblockCommand(
 ): Promise<string> {
   const { store } = requireCtx(context);
   const args = [...rawArgs];
+  const json = takeBoolFlag(args, "--json");
   const by = requireBy(args);
   const positionals = requirePositionals(
     args,
@@ -317,29 +353,31 @@ export async function unblockCommand(
   );
   const id = requireId(positionals[0], "id");
 
-  if (!(await store.get(id))) {
-    throw notFound(id, { globals: context?.suggestionGlobals });
-  }
+  const current = await store.get(id);
+  if (!current) throw notFound(id, { globals: context?.suggestionGlobals });
   const removed = await store.removeDep(id, { type: "blocked-by", id: by });
 
-  const blocks: string[] = [];
-  if (!removed) blocks.push("already: true");
-  blocks.push(
-    renderDetail("unblock", { id, blocked_by: by }, [
-      field("id"),
-      field("blocked_by"),
-    ]),
-  );
-  blocks.push(
-    renderHelp(
-      getSuggestions({
-        action: "unblock",
-        id,
-        globals: context?.suggestionGlobals,
-      }),
-    ),
-  );
-  return renderOutput(blocks);
+  const all = (await store.list({})).items;
+  const task = all.find((t) => t.id === id) ?? current;
+  return renderMutation({
+    json,
+    confirm: removed
+      ? `unblock ${id} -> cleared ${by}`
+      : `unblock ${id} already not blocked-by ${by}`,
+    already: !removed,
+    jsonPayload: {
+      ok: true,
+      action: "unblock",
+      ...(removed ? {} : { already: true }),
+      blocked_by: by,
+      task: taskToJson(task, all),
+    },
+    suggestions: getSuggestions({
+      action: "unblock",
+      id,
+      globals: context?.suggestionGlobals,
+    }),
+  });
 }
 
 export async function readyCommand(
@@ -417,6 +455,7 @@ export async function mvCommand(
   const { store, config } = requireCtx(context);
   const args = [...rawArgs];
 
+  const json = takeBoolFlag(args, "--json");
   const to = requireNonEmptySingleLineFlagValue("--to", takeFlag(args, "--to"));
   if (to === undefined) {
     throw new AxiError("--to <path-or-dir> is required", "VALIDATION_ERROR", [
@@ -451,11 +490,20 @@ export async function mvCommand(
     await store.remove(id);
   }
 
-  return renderOutput([
-    renderDetail("moved", { id, from: config.path, to: targetPath }, [
-      field("id"),
-      field("from"),
-      field("to"),
-    ]),
-  ]);
+  return renderMutation({
+    json,
+    confirm: `mv ${id} -> ${targetPath}`,
+    jsonPayload: {
+      ok: true,
+      action: "mv",
+      id,
+      from: config.path,
+      to: targetPath,
+    },
+    suggestions: getSuggestions({
+      action: "mv",
+      id,
+      globals: context?.suggestionGlobals,
+    }),
+  });
 }

--- a/src/commands/state.ts
+++ b/src/commands/state.ts
@@ -10,11 +10,7 @@ import {
   takeBoolFlag,
   takeFlag,
 } from "../args.js";
-import {
-  renderMutation,
-  stateLabel,
-  taskToJson,
-} from "../confirm.js";
+import { renderMutation, stateLabel, taskToJson } from "../confirm.js";
 import { requireCtx, type TasksContext } from "../context.js";
 import { readyTasks } from "../derive.js";
 import { AxiError, notFound } from "../errors.js";
@@ -193,7 +189,10 @@ export async function doneCommand(
 }
 
 /** The `(pr X, report Y)` parenthetical for a done confirmation, omitted when bare. */
-function doneExtras(pr: string | undefined, report: string | undefined): string {
+function doneExtras(
+  pr: string | undefined,
+  report: string | undefined,
+): string {
   const parts: string[] = [];
   if (pr !== undefined) parts.push(`pr ${pr}`);
   if (report !== undefined) parts.push(`report ${report}`);
@@ -247,7 +246,12 @@ export async function reopenCommand(
   const { store } = requireCtx(context);
   const args = [...rawArgs];
   const json = takeBoolFlag(args, "--json");
-  const positionals = requirePositionals(args, 1, 1, REOPEN_HELP.split("\n")[0]);
+  const positionals = requirePositionals(
+    args,
+    1,
+    1,
+    REOPEN_HELP.split("\n")[0],
+  );
   const id = requireId(positionals[0], "id");
 
   const current = await store.get(id);

--- a/src/confirm.ts
+++ b/src/confirm.ts
@@ -1,10 +1,12 @@
 /**
  * Confirmation-forward output for write operations (AXI house style §6, §9).
  *
- * Every mutation leads with a terse `ok:` line that confirms the *resulting
- * state*, not just the next step, so an agent can see what landed without a
- * follow-up read. The same verbs also accept `--json` for a deterministic,
- * machine-readable result object (the human-readable TOON form stays default).
+ * Every mutation leads with a terse `ok:` line that confirms the write result,
+ * not just the next step, so an agent can see what landed without a follow-up
+ * read.
+ * Task-state mutations include the resulting state.
+ * The same verbs also accept `--json` for a deterministic, machine-readable
+ * result object (the human-readable TOON form stays default).
  */
 
 import { activeBlockers } from "./derive.js";
@@ -25,10 +27,10 @@ export function stateLabel(state: State): string {
 /**
  * The leading confirmation line every mutation prints. Emitted as a plain
  * `ok: <message>` line (a top-level TOON scalar) so it stays a readable,
- * terse confirmation of the resulting state and a deterministic success
- * marker. Confirmation messages are built from bounded values (ids, names,
- * validated urls/paths, counts), so the line round-trips through TOON without
- * quoting; the `--json` form is the guaranteed-parseable machine signal.
+ * terse confirmation of the write result and a deterministic success marker.
+ * Confirmation messages are built from bounded values (ids, names, validated
+ * urls/paths, counts), so the line round-trips through TOON without quoting;
+ * the `--json` form is the guaranteed-parseable machine signal.
  */
 export function renderConfirm(message: string): string {
   return `ok: ${message}`;
@@ -44,7 +46,7 @@ export interface MutationOutput {
   json: boolean;
   /** The machine-readable result object for `--json`. */
   jsonPayload: Record<string, unknown>;
-  /** The leading `ok:` confirmation message (resulting state). */
+  /** The leading `ok:` confirmation message (write result). */
   confirm: string;
   /** Emit the `already: true` no-op signal. */
   already?: boolean;

--- a/src/confirm.ts
+++ b/src/confirm.ts
@@ -1,0 +1,102 @@
+/**
+ * Confirmation-forward output for write operations (AXI house style §6, §9).
+ *
+ * Every mutation leads with a terse `ok:` line that confirms the *resulting
+ * state*, not just the next step, so an agent can see what landed without a
+ * follow-up read. The same verbs also accept `--json` for a deterministic,
+ * machine-readable result object (the human-readable TOON form stays default).
+ */
+
+import { activeBlockers } from "./derive.js";
+import type { State, Task } from "./model.js";
+import { renderHelp, renderOutput } from "./toon.js";
+
+const STATE_LABELS: Record<State, string> = {
+  queued: "Queued",
+  in_flight: "In flight",
+  done: "Done",
+};
+
+/** Human-readable resulting-state name for confirmation lines. */
+export function stateLabel(state: State): string {
+  return STATE_LABELS[state];
+}
+
+/**
+ * The leading confirmation line every mutation prints. Emitted as a plain
+ * `ok: <message>` line (a top-level TOON scalar) so it stays a readable,
+ * terse confirmation of the resulting state and a deterministic success
+ * marker. Confirmation messages are built from bounded values (ids, names,
+ * validated urls/paths, counts), so the line round-trips through TOON without
+ * quoting; the `--json` form is the guaranteed-parseable machine signal.
+ */
+export function renderConfirm(message: string): string {
+  return `ok: ${message}`;
+}
+
+/** Pretty-printed JSON result for `--json` (machine-readable, opt-in). */
+export function renderJson(payload: Record<string, unknown>): string {
+  return JSON.stringify(payload, null, 2);
+}
+
+export interface MutationOutput {
+  /** When true, emit the JSON payload instead of the human-readable blocks. */
+  json: boolean;
+  /** The machine-readable result object for `--json`. */
+  jsonPayload: Record<string, unknown>;
+  /** The leading `ok:` confirmation message (resulting state). */
+  confirm: string;
+  /** Emit the `already: true` no-op signal. */
+  already?: boolean;
+  /** An optional structured detail block (e.g. the full task record). */
+  detail?: string;
+  /** State-aware next-step hints (already resolved to lines). */
+  suggestions?: string[];
+}
+
+/**
+ * Assemble a mutation's output: a single JSON object under `--json`, otherwise
+ * the confirmation-forward TOON blocks (confirm line, optional `already`,
+ * optional detail, then state-aware hints).
+ */
+export function renderMutation(output: MutationOutput): string {
+  if (output.json) return renderJson(output.jsonPayload);
+  const blocks = [renderConfirm(output.confirm)];
+  if (output.already) blocks.push("already: true");
+  if (output.detail) blocks.push(output.detail);
+  if (output.suggestions && output.suggestions.length > 0) {
+    blocks.push(renderHelp(output.suggestions));
+  }
+  return renderOutput(blocks);
+}
+
+/**
+ * Clean JSON projection of a task for `--json`: real values, untruncated text,
+ * `null` for absent fields, plus the derived `blocked`/`blocked_by` when the
+ * full task set is supplied.
+ */
+export function taskToJson(task: Task, all?: Task[]): Record<string, unknown> {
+  const json: Record<string, unknown> = {
+    id: task.id,
+    title: task.title,
+    state: task.state,
+    kind: task.kind ?? null,
+    repo: task.repo ?? null,
+    priority: task.priority ?? null,
+    created: task.created ?? null,
+    closed: task.closed ?? null,
+    deps: task.deps.map((d) => ({
+      type: d.type,
+      id: d.id,
+      ...(d.reason !== undefined ? { reason: d.reason } : {}),
+    })),
+    links: task.links.map((l) => ({ kind: l.kind, url: l.url })),
+    body: task.body ?? null,
+  };
+  if (all) {
+    const blockers = activeBlockers(task, all);
+    json.blocked = blockers.length > 0;
+    json.blocked_by = blockers;
+  }
+  return json;
+}

--- a/src/skill.ts
+++ b/src/skill.ts
@@ -82,7 +82,8 @@ Run \`npx -y tasks-axi --help\` for global flags, or \`npx -y tasks-axi <command
 ## Tips
 
 - Output is TOON-encoded and token-efficient; the long task body is truncated by default - the whole point is that \`list\` stays cheap. Use \`--full\` only when you need the complete notes.
-- Mutations are idempotent and report what changed (\`already: true\` on a no-op); re-running a mutation is safe.
+- Every write leads with an \`ok:\` line confirming the resulting state (e.g. \`ok: start <id> -> In flight\`, \`ok: done <id> -> Done (pr <url>)\`), then state-aware next-step hints. Mutations are idempotent and add \`already: true\` on a no-op; re-running is safe.
+- Pass \`--json\` to any mutation (\`add\`, \`start\`, \`done\`, \`reopen\`, \`update\`, \`rm\`, \`block\`, \`unblock\`, \`mv\`, \`prune\`, \`render\`) for a machine-readable result object (\`{ "ok": true, "action": ..., "task": { ... } }\`) instead of TOON - confirm a write deterministically without a follow-up read.
 - \`block <id> --by <other>\` and \`unblock\` manage the dependency graph; \`ready\` lists only queued work with no unresolved blocker.
 - Filter \`list\` with \`--state\`, \`--repo\`, \`--kind\`, \`--blocked\`, \`--limit\`, and add columns with \`--fields a,b,c\`.
 - \`update <id> --append "<note>"\` adds to a task's body; \`update <id> --body "<text>"\` or \`--body-file <path>\` replaces it, and \`--title "<text>"\` replaces the title; \`render\` normalizes the file; \`mv <id> --to <path>\` moves a task to another backlog.

--- a/src/skill.ts
+++ b/src/skill.ts
@@ -69,7 +69,8 @@ Use tasks-axi whenever a task touches the backlog: filing or dispatching work, m
 3. The long notes never appear in \`list\`; run \`show <id> --full\` to read a task's complete body.
 4. \`add\` takes a caller-supplied id (the join key), e.g. \`tasks-axi add fm-x "title" --kind ship --repo firstmate --start\`; or pass \`--mint\` to generate a slug-xx id from the title.
 5. \`done <id> --pr <url>\` (or \`--report <path>\`) closes a task, records the link, and prunes the Done list (archived, never deleted). Then \`ready\` shows work it unblocked.
-6. Every response ends with contextual next-step hints under \`help:\` - follow them.
+6. Human-readable responses include contextual next-step hints under \`help:\` when there is a useful follow-up - follow them.
+7. \`--json\` mutation responses skip \`help:\` and return the deterministic result object instead.
 
 ## Commands
 
@@ -81,9 +82,11 @@ Run \`npx -y tasks-axi --help\` for global flags, or \`npx -y tasks-axi <command
 
 ## Tips
 
-- Output is TOON-encoded and token-efficient; the long task body is truncated by default - the whole point is that \`list\` stays cheap. Use \`--full\` only when you need the complete notes.
-- Every write leads with an \`ok:\` line confirming the resulting state (e.g. \`ok: start <id> -> In flight\`, \`ok: done <id> -> Done (pr <url>)\`), then state-aware next-step hints. Mutations are idempotent and add \`already: true\` on a no-op; re-running is safe.
-- Pass \`--json\` to any mutation (\`add\`, \`start\`, \`done\`, \`reopen\`, \`update\`, \`rm\`, \`block\`, \`unblock\`, \`mv\`, \`prune\`, \`render\`) for a machine-readable result object (\`{ "ok": true, "action": ..., "task": { ... } }\`) instead of TOON - confirm a write deterministically without a follow-up read.
+- Output is TOON-encoded and token-efficient; the long task body is truncated by default - the whole point is that \`list\` stays cheap.
+  Use \`--full\` only when you need the complete notes.
+- Every write leads with an \`ok:\` line confirming the write result, including the resulting task state when the command changes one (e.g. \`ok: start <id> -> In flight\`, \`ok: done <id> -> Done (pr <url>)\`, \`ok: render -> normalized <n>\`), then state-aware next-step hints.
+  Mutations are idempotent and add \`already: true\` on a no-op; re-running is safe.
+- Pass \`--json\` to any mutation (\`add\`, \`start\`, \`done\`, \`reopen\`, \`update\`, \`rm\`, \`block\`, \`unblock\`, \`mv\`, \`prune\`, \`render\`) for a machine-readable result object (\`{ "ok": true, "action": ..., "task": { ... } }\` or operation-specific result fields) instead of TOON - confirm a write deterministically without a follow-up read.
 - \`block <id> --by <other>\` and \`unblock\` manage the dependency graph; \`ready\` lists only queued work with no unresolved blocker.
 - Filter \`list\` with \`--state\`, \`--repo\`, \`--kind\`, \`--blocked\`, \`--limit\`, and add columns with \`--fields a,b,c\`.
 - \`update <id> --append "<note>"\` adds to a task's body; \`update <id> --body "<text>"\` or \`--body-file <path>\` replaces it, and \`--title "<text>"\` replaces the title; \`render\` normalizes the file; \`mv <id> --to <path>\` moves a task to another backlog.

--- a/src/suggestions.ts
+++ b/src/suggestions.ts
@@ -51,11 +51,10 @@ const table: Entry[] = [
     match: (c) => c.action === "list" && c.isEmpty === true,
     lines: (c) =>
       compact([
-        suggestionLine(
-          'Run `tasks-axi add <id> "<title>"` to add a task',
-          c,
-          ["repo", "kind"],
-        ),
+        suggestionLine('Run `tasks-axi add <id> "<title>"` to add a task', c, [
+          "repo",
+          "kind",
+        ]),
         suggestionLine(
           "Run `tasks-axi list --state done` to see completed work",
           c,
@@ -121,9 +120,7 @@ const table: Entry[] = [
   },
   {
     match: (c) => c.action === "start",
-    lines: (c) => [
-      `Run \`tasks-axi done ${c.id} --pr <url>\` when it ships`,
-    ],
+    lines: (c) => [`Run \`tasks-axi done ${c.id} --pr <url>\` when it ships`],
   },
   {
     match: (c) => c.action === "done",
@@ -154,7 +151,9 @@ const table: Entry[] = [
   },
   {
     match: (c) => c.action === "prune",
-    lines: () => ["Run `tasks-axi list --state done` to see retained Done items"],
+    lines: () => [
+      "Run `tasks-axi list --state done` to see retained Done items",
+    ],
   },
   {
     match: (c) => c.action === "mv",
@@ -188,7 +187,9 @@ export function withSuggestionGlobals(
   });
 }
 
-function globalSuffix(globals: SuggestionGlobals | undefined): string | undefined {
+function globalSuffix(
+  globals: SuggestionGlobals | undefined,
+): string | undefined {
   if (!globals) return "";
   const parts: string[] = [];
   if (globals.backend !== undefined) {
@@ -204,7 +205,10 @@ function globalSuffix(globals: SuggestionGlobals | undefined): string | undefine
   return parts.length > 0 ? ` ${parts.join(" ")}` : "";
 }
 
-function appendSuffixToCommand(line: string, suffix: string): string | undefined {
+function appendSuffixToCommand(
+  line: string,
+  suffix: string,
+): string | undefined {
   const first = line.indexOf("`");
   if (first === -1) return undefined;
   const second = line.indexOf("`", first + 1);

--- a/src/suggestions.ts
+++ b/src/suggestions.ts
@@ -10,6 +10,12 @@ export interface SuggestionContext {
   isEmpty?: boolean;
   /** A blocked task suggests unblocking; an empty ready list suggests listing. */
   blocked?: boolean;
+  /**
+   * The resulting state after a mutation. Lets hints stay state-aware so a
+   * command never suggests an action it just performed (e.g. no "run start"
+   * after `add --start`).
+   */
+  state?: string;
   globals?: SuggestionGlobals;
   filters?: SuggestionFilters;
 }
@@ -92,6 +98,21 @@ const table: Entry[] = [
     ],
   },
   {
+    // `add --start` (or re-adding an in-flight task) already moved it, so the
+    // genuinely useful next step is closing it, never "run start".
+    match: (c) => c.action === "add" && c.state === "in_flight",
+    lines: (c) => [
+      `Run \`tasks-axi done ${c.id} --pr <url>\` when it ships`,
+      `Run \`tasks-axi block ${c.id} --by <other>\` to record a dependency`,
+    ],
+  },
+  {
+    match: (c) => c.action === "add" && c.state === "done",
+    lines: (c) => [
+      `Run \`tasks-axi reopen ${c.id}\` to move it back to queued`,
+    ],
+  },
+  {
     match: (c) => c.action === "add",
     lines: (c) => [
       `Run \`tasks-axi start ${c.id}\` to move it to in flight`,
@@ -134,6 +155,14 @@ const table: Entry[] = [
   {
     match: (c) => c.action === "prune",
     lines: () => ["Run `tasks-axi list --state done` to see retained Done items"],
+  },
+  {
+    match: (c) => c.action === "mv",
+    lines: () => ["Run `tasks-axi list` to see remaining tasks"],
+  },
+  {
+    match: (c) => c.action === "render",
+    lines: () => ["Run `tasks-axi list` to see the normalized backlog"],
   },
 ];
 

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -93,12 +93,27 @@ describe("CLI entrypoint", () => {
   it("performs a mutation end to end", async () => {
     const c = capture();
     await main({ argv: ["start", "cert-cleanup"], stdout: c.stdout });
-    expect(c.read()).toContain("state: in_flight");
+    expect(c.read()).toContain("ok: start cert-cleanup -> In flight");
     // In-flight items render in firstmate's `- [ ]` checkbox form, under the
     // In flight header (the section, not the bullet, carries the state).
     expect(readFileSync(path, "utf8")).toMatch(
       /## In flight[\s\S]*- \[ \] cert-cleanup/,
     );
+  });
+
+  it("emits machine-readable JSON for a mutation with --json", async () => {
+    const c = capture();
+    await main({ argv: ["start", "cert-cleanup", "--json"], stdout: c.stdout });
+    const parsed = JSON.parse(c.read()) as {
+      ok: boolean;
+      action: string;
+      task: { id: string; state: string };
+    };
+    expect(parsed.ok).toBe(true);
+    expect(parsed.action).toBe("start");
+    expect(parsed.task.id).toBe("cert-cleanup");
+    expect(parsed.task.state).toBe("in_flight");
+    expect(process.exitCode).toBeFalsy();
   });
 
   it("rejects unknown mutation flags instead of shifting positionals", async () => {

--- a/test/commands/crud.test.ts
+++ b/test/commands/crud.test.ts
@@ -31,9 +31,75 @@ describe("crud commands", () => {
     it("adds directly to In flight with --start", async () => {
       const b = makeBacklog();
       try {
-        await addCommand(["new-h1", "started task", "--start"], b.ctx);
+        const out = await addCommand(
+          ["new-h1", "started task", "--kind", "ship", "--repo", "demo", "--start"],
+          b.ctx,
+        );
+        // The confirmation line leads with the resulting state.
+        expect(out).toContain(
+          "ok: added new-h1 (ship, repo demo) -> In flight",
+        );
+        // State-aware hints never suggest the action --start already performed.
+        expect(out).not.toContain("Run `tasks-axi start new-h1`");
+        expect(out).toContain("Run `tasks-axi done new-h1 --pr <url>`");
         // In-flight items use firstmate's `- [ ]` checkbox form under the header.
         expect(b.read()).toMatch(/## In flight[\s\S]*- \[ \] new-h1/);
+      } finally {
+        b.cleanup();
+      }
+    });
+
+    it("keeps the confirmation-forward output valid TOON", async () => {
+      const b = makeBacklog();
+      try {
+        const out = await addCommand(
+          ["toon-q1", "round trips", "--kind", "ship", "--repo", "demo", "--start"],
+          b.ctx,
+        );
+        // The leading ok: line carries commas (`(ship, repo demo)`) yet the
+        // whole block still decodes - it is the human-readable success signal.
+        const decoded = decode(out) as { ok: string };
+        expect(decoded.ok).toBe("added toon-q1 (ship, repo demo) -> In flight");
+      } finally {
+        b.cleanup();
+      }
+    });
+
+    it("confirms a queued add and suggests start, not done", async () => {
+      const b = makeBacklog();
+      try {
+        const out = await addCommand(["new-q9", "queued task"], b.ctx);
+        expect(out).toContain("ok: added new-q9 -> Queued");
+        expect(out).toContain("Run `tasks-axi start new-q9`");
+        expect(out).not.toContain("Run `tasks-axi done new-q9");
+      } finally {
+        b.cleanup();
+      }
+    });
+
+    it("emits a machine-readable task with --json", async () => {
+      const b = makeBacklog();
+      try {
+        const out = await addCommand(
+          ["json-q1", "json task", "--kind", "ship", "--repo", "demo", "--json"],
+          b.ctx,
+        );
+        const parsed = JSON.parse(out) as {
+          ok: boolean;
+          action: string;
+          task: { id: string; state: string; kind: string; repo: string };
+        };
+        expect(parsed.ok).toBe(true);
+        expect(parsed.action).toBe("add");
+        expect(parsed.task).toMatchObject({
+          id: "json-q1",
+          state: "queued",
+          kind: "ship",
+          repo: "demo",
+        });
+        // --json suppresses the human-readable TOON blocks.
+        expect(out).not.toContain("help[");
+        expect(out).not.toContain("task:");
       } finally {
         b.cleanup();
       }
@@ -557,8 +623,45 @@ describe("crud commands", () => {
           ["cert-cleanup", "--append", "step 2 in progress"],
           b.ctx,
         );
+        expect(out).toContain("ok: updated cert-cleanup (note)");
         expect(out).toContain("id: cert-cleanup");
         expect(b.read()).toContain("\n  step 2 in progress");
+      } finally {
+        b.cleanup();
+      }
+    });
+
+    it("lists every changed field in the confirmation", async () => {
+      const b = makeBacklog();
+      try {
+        const out = await updateCommand(
+          ["cert-cleanup", "--title", "renamed", "--repo", "demo"],
+          b.ctx,
+        );
+        expect(out).toContain("ok: updated cert-cleanup (title, repo)");
+      } finally {
+        b.cleanup();
+      }
+    });
+
+    it("emits a machine-readable task with --json", async () => {
+      const b = makeBacklog();
+      try {
+        const out = await updateCommand(
+          ["cert-cleanup", "--append", "json note", "--json"],
+          b.ctx,
+        );
+        const parsed = JSON.parse(out) as {
+          ok: boolean;
+          action: string;
+          changed: string[];
+          task: { id: string };
+        };
+        expect(parsed.ok).toBe(true);
+        expect(parsed.action).toBe("update");
+        expect(parsed.changed).toContain("note");
+        expect(parsed.task.id).toBe("cert-cleanup");
+        expect(out).not.toContain("help[");
       } finally {
         b.cleanup();
       }
@@ -688,7 +791,29 @@ describe("crud commands", () => {
       const b = makeBacklog();
       try {
         const out = await rmCommand(["cert-cleanup"], b.ctx);
-        expect(out).toContain("removed:");
+        expect(out).toContain("ok: removed cert-cleanup");
+        expect(b.read()).not.toContain("cert-cleanup");
+      } finally {
+        b.cleanup();
+      }
+    });
+
+    it("emits a machine-readable result with --json", async () => {
+      const b = makeBacklog();
+      try {
+        const out = await rmCommand(["cert-cleanup", "--json"], b.ctx);
+        const parsed = JSON.parse(out) as {
+          ok: boolean;
+          action: string;
+          id: string;
+          removed: boolean;
+        };
+        expect(parsed).toMatchObject({
+          ok: true,
+          action: "rm",
+          id: "cert-cleanup",
+          removed: true,
+        });
         expect(b.read()).not.toContain("cert-cleanup");
       } finally {
         b.cleanup();

--- a/test/commands/crud.test.ts
+++ b/test/commands/crud.test.ts
@@ -32,7 +32,15 @@ describe("crud commands", () => {
       const b = makeBacklog();
       try {
         const out = await addCommand(
-          ["new-h1", "started task", "--kind", "ship", "--repo", "demo", "--start"],
+          [
+            "new-h1",
+            "started task",
+            "--kind",
+            "ship",
+            "--repo",
+            "demo",
+            "--start",
+          ],
           b.ctx,
         );
         // The confirmation line leads with the resulting state.
@@ -53,7 +61,15 @@ describe("crud commands", () => {
       const b = makeBacklog();
       try {
         const out = await addCommand(
-          ["toon-q1", "round trips", "--kind", "ship", "--repo", "demo", "--start"],
+          [
+            "toon-q1",
+            "round trips",
+            "--kind",
+            "ship",
+            "--repo",
+            "demo",
+            "--start",
+          ],
           b.ctx,
         );
         // The leading ok: line carries commas (`(ship, repo demo)`) yet the
@@ -81,7 +97,15 @@ describe("crud commands", () => {
       const b = makeBacklog();
       try {
         const out = await addCommand(
-          ["json-q1", "json task", "--kind", "ship", "--repo", "demo", "--json"],
+          [
+            "json-q1",
+            "json task",
+            "--kind",
+            "ship",
+            "--repo",
+            "demo",
+            "--json",
+          ],
           b.ctx,
         );
         const parsed = JSON.parse(out) as {
@@ -183,16 +207,19 @@ describe("crud commands", () => {
       ["missing blocker", "dup title", ["--blocked-by", "missing-q1"]],
       ["tag-injecting repo", "dup title", ["--repo", "foo(bar)"]],
       ["tagging title", "dup title (repo: foo)", []],
-    ])("rejects %s before duplicate add no-ops", async (_case, title, flagArgs) => {
-      const b = makeBacklog();
-      try {
-        await expect(
-          addCommand(["lease-adopt", title, ...flagArgs], b.ctx),
-        ).rejects.toMatchObject({ code: "VALIDATION_ERROR" });
-      } finally {
-        b.cleanup();
-      }
-    });
+    ])(
+      "rejects %s before duplicate add no-ops",
+      async (_case, title, flagArgs) => {
+        const b = makeBacklog();
+        try {
+          await expect(
+            addCommand(["lease-adopt", title, ...flagArgs], b.ctx),
+          ).rejects.toMatchObject({ code: "VALIDATION_ERROR" });
+        } finally {
+          b.cleanup();
+        }
+      },
+    );
 
     it("rejects an invalid id", async () => {
       const b = makeBacklog();
@@ -208,9 +235,9 @@ describe("crud commands", () => {
     it("rejects a blank title before creating a task", async () => {
       const b = makeBacklog();
       try {
-        await expect(addCommand(["blank-q1", "   "], b.ctx)).rejects.toMatchObject(
-          { code: "VALIDATION_ERROR" },
-        );
+        await expect(
+          addCommand(["blank-q1", "   "], b.ctx),
+        ).rejects.toMatchObject({ code: "VALIDATION_ERROR" });
         expect(b.read()).not.toContain("blank-q1");
       } finally {
         b.cleanup();
@@ -232,9 +259,9 @@ describe("crud commands", () => {
     it("rejects a blank minted title", async () => {
       const b = makeBacklog();
       try {
-        await expect(addCommand(["   ", "--mint"], b.ctx)).rejects.toMatchObject(
-          { code: "VALIDATION_ERROR" },
-        );
+        await expect(
+          addCommand(["   ", "--mint"], b.ctx),
+        ).rejects.toMatchObject({ code: "VALIDATION_ERROR" });
       } finally {
         b.cleanup();
       }
@@ -280,7 +307,10 @@ describe("crud commands", () => {
       const b = makeBacklog();
       try {
         await expect(
-          addCommand(["new-q1", "bad dep", "--blocked-by", "missing-q1"], b.ctx),
+          addCommand(
+            ["new-q1", "bad dep", "--blocked-by", "missing-q1"],
+            b.ctx,
+          ),
         ).rejects.toMatchObject({ code: "VALIDATION_ERROR" });
         expect(b.read()).not.toContain("new-q1");
         expect(b.read()).not.toContain("missing-q1");
@@ -293,7 +323,10 @@ describe("crud commands", () => {
       const b = makeBacklog();
       try {
         await expect(
-          addCommand(["new-q1", "self blocked", "--blocked-by", "new-q1"], b.ctx),
+          addCommand(
+            ["new-q1", "self blocked", "--blocked-by", "new-q1"],
+            b.ctx,
+          ),
         ).rejects.toMatchObject({ code: "VALIDATION_ERROR" });
         expect(b.read()).not.toContain("new-q1");
       } finally {
@@ -827,7 +860,9 @@ describe("crud commands", () => {
           type: "blocked-by",
           id: "owns-widget-h7",
         });
-        await expect(rmCommand(["owns-widget-h7"], b.ctx)).rejects.toMatchObject({
+        await expect(
+          rmCommand(["owns-widget-h7"], b.ctx),
+        ).rejects.toMatchObject({
           code: "VALIDATION_ERROR",
           message: expect.stringContaining("cert-cleanup"),
           suggestions: expect.arrayContaining([

--- a/test/commands/maintain.test.ts
+++ b/test/commands/maintain.test.ts
@@ -119,9 +119,9 @@ describe("maintenance commands", () => {
     it("rejects extra arguments before rendering", async () => {
       const b = makeBacklog();
       try {
-        await expect(
-          renderCommand(["extra"], b.ctx),
-        ).rejects.toMatchObject({ code: "VALIDATION_ERROR" });
+        await expect(renderCommand(["extra"], b.ctx)).rejects.toMatchObject({
+          code: "VALIDATION_ERROR",
+        });
       } finally {
         b.cleanup();
       }

--- a/test/commands/maintain.test.ts
+++ b/test/commands/maintain.test.ts
@@ -8,9 +8,32 @@ describe("maintenance commands", () => {
       const b = makeBacklog();
       try {
         const out = await pruneCommand(["--keep", "2"], b.ctx);
-        expect(out).toContain("prune:");
-        expect(out).toMatch(/archived: [1-9]/);
+        expect(out).toMatch(/ok: prune done -> archived [1-9]\d* \(kept 2\)/);
         expect(b.archive()).toContain("## Archived");
+      } finally {
+        b.cleanup();
+      }
+    });
+
+    it("emits a machine-readable result with --json", async () => {
+      const b = makeBacklog();
+      try {
+        const out = await pruneCommand(["--keep", "2", "--json"], b.ctx);
+        const parsed = JSON.parse(out) as {
+          ok: boolean;
+          action: string;
+          state: string;
+          kept: number;
+          archived: number;
+          ids: string[];
+        };
+        expect(parsed.ok).toBe(true);
+        expect(parsed.action).toBe("prune");
+        expect(parsed.state).toBe("done");
+        expect(parsed.kept).toBe(2);
+        expect(parsed.archived).toBeGreaterThan(0);
+        expect(Array.isArray(parsed.ids)).toBe(true);
+        expect(out).not.toContain("help[");
       } finally {
         b.cleanup();
       }
@@ -70,7 +93,24 @@ describe("maintenance commands", () => {
       const b = makeBacklog();
       try {
         const out = await renderCommand([], b.ctx);
-        expect(out).toMatch(/normalized: \d+/);
+        expect(out).toMatch(/ok: render -> normalized \d+/);
+      } finally {
+        b.cleanup();
+      }
+    });
+
+    it("emits a machine-readable result with --json", async () => {
+      const b = makeBacklog();
+      try {
+        const out = await renderCommand(["--json"], b.ctx);
+        const parsed = JSON.parse(out) as {
+          ok: boolean;
+          action: string;
+          normalized: number;
+        };
+        expect(parsed.ok).toBe(true);
+        expect(parsed.action).toBe("render");
+        expect(typeof parsed.normalized).toBe("number");
       } finally {
         b.cleanup();
       }

--- a/test/commands/state.test.ts
+++ b/test/commands/state.test.ts
@@ -101,7 +101,12 @@ describe("state commands", () => {
       const b = makeBacklog();
       try {
         const out = await doneCommand(
-          ["cert-cleanup", "--pr", "https://github.com/o/r/pull/9", "--no-prune"],
+          [
+            "cert-cleanup",
+            "--pr",
+            "https://github.com/o/r/pull/9",
+            "--no-prune",
+          ],
           b.ctx,
         );
         expect(out).toContain(
@@ -132,7 +137,11 @@ describe("state commands", () => {
           ok: boolean;
           action: string;
           pruned: number;
-          task: { id: string; state: string; links: { kind: string; url: string }[] };
+          task: {
+            id: string;
+            state: string;
+            links: { kind: string; url: string }[];
+          };
         };
         expect(parsed.ok).toBe(true);
         expect(parsed.action).toBe("done");
@@ -348,7 +357,9 @@ describe("state commands", () => {
           ["cert-cleanup", "--by", "owns-widget-h7"],
           b.ctx,
         );
-        expect(added).toContain("ok: block cert-cleanup -> blocked-by owns-widget-h7");
+        expect(added).toContain(
+          "ok: block cert-cleanup -> blocked-by owns-widget-h7",
+        );
         expect(b.read()).toContain("blocked-by: owns-widget-h7");
 
         const again = await blockCommand(
@@ -365,7 +376,9 @@ describe("state commands", () => {
           b.ctx,
         );
         expect(cleared).not.toContain("already: true");
-        expect(cleared).toContain("ok: unblock cert-cleanup -> cleared owns-widget-h7");
+        expect(cleared).toContain(
+          "ok: unblock cert-cleanup -> cleared owns-widget-h7",
+        );
         expect(b.read()).not.toContain("blocked-by: owns-widget-h7");
       } finally {
         b.cleanup();
@@ -449,7 +462,10 @@ describe("state commands", () => {
       const b = makeBacklog();
       try {
         await expect(
-          blockCommand(["cert-cleanup", "extra", "--by", "owns-widget-h7"], b.ctx),
+          blockCommand(
+            ["cert-cleanup", "extra", "--by", "owns-widget-h7"],
+            b.ctx,
+          ),
         ).rejects.toMatchObject({ code: "VALIDATION_ERROR" });
         expect(b.read()).not.toContain("blocked-by: owns-widget-h7");
       } finally {
@@ -523,9 +539,14 @@ describe("state commands", () => {
   describe("mv", () => {
     it("moves a task to another backlog file", async () => {
       const b = makeBacklog();
-      const target = makeBacklog("# Backlog\n\n## In flight\n\n## Queued\n\n## Done\n");
+      const target = makeBacklog(
+        "# Backlog\n\n## In flight\n\n## Queued\n\n## Done\n",
+      );
       try {
-        const out = await mvCommand(["cert-cleanup", "--to", target.path], b.ctx);
+        const out = await mvCommand(
+          ["cert-cleanup", "--to", target.path],
+          b.ctx,
+        );
         expect(out).toContain(`ok: mv cert-cleanup -> ${target.path}`);
         expect(b.read()).not.toContain("cert-cleanup");
         expect(readFileSync(target.path, "utf8")).toContain("cert-cleanup");
@@ -588,7 +609,9 @@ describe("state commands", () => {
       const b = makeBacklog(
         "# Backlog\n\n## Queued\n- [ ] race-q1 - stale title\n\n## Done\n",
       );
-      const target = makeBacklog("# Backlog\n\n## In flight\n\n## Queued\n\n## Done\n");
+      const target = makeBacklog(
+        "# Backlog\n\n## In flight\n\n## Queued\n\n## Done\n",
+      );
       const originalGet = b.store.get.bind(b.store);
       let edited = false;
       b.store.get = async (taskId: string) => {
@@ -618,7 +641,9 @@ describe("state commands", () => {
       const b = makeBacklog(
         "# Backlog\n\n## Queued\n- [ ] bad-q1 - invalid parsed repo (repo: foo(bar)\n\n## Done\n",
       );
-      const target = makeBacklog("# Backlog\n\n## In flight\n\n## Queued\n\n## Done\n");
+      const target = makeBacklog(
+        "# Backlog\n\n## In flight\n\n## Queued\n\n## Done\n",
+      );
       try {
         await expect(
           mvCommand(["bad-q1", "--to", target.path], b.ctx),
@@ -635,7 +660,9 @@ describe("state commands", () => {
       const b = makeBacklog(
         "# Backlog\n\n## Queued\n- [ ] legacy-q1 - legacy without since\n\n## Done\n",
       );
-      const target = makeBacklog("# Backlog\n\n## In flight\n\n## Queued\n\n## Done\n");
+      const target = makeBacklog(
+        "# Backlog\n\n## In flight\n\n## Queued\n\n## Done\n",
+      );
       try {
         await mvCommand(["legacy-q1", "--to", target.path], b.ctx);
 
@@ -691,7 +718,9 @@ describe("state commands", () => {
           ]),
         });
         expect(b.read()).toContain("owns-widget-h7");
-        expect(readFileSync(target.path, "utf8")).not.toContain("owns-widget-h7");
+        expect(readFileSync(target.path, "utf8")).not.toContain(
+          "owns-widget-h7",
+        );
       } finally {
         b.cleanup();
         target.cleanup();

--- a/test/commands/state.test.ts
+++ b/test/commands/state.test.ts
@@ -41,7 +41,8 @@ describe("state commands", () => {
       const b = makeBacklog();
       try {
         const out = await startCommand(["cert-cleanup"], b.ctx);
-        expect(out).toContain("state: in_flight");
+        expect(out).toContain("ok: start cert-cleanup -> In flight");
+        expect(out).toContain("Run `tasks-axi done cert-cleanup --pr <url>`");
       } finally {
         b.cleanup();
       }
@@ -53,6 +54,30 @@ describe("state commands", () => {
         await startCommand(["cert-cleanup"], b.ctx);
         const out = await startCommand(["cert-cleanup"], b.ctx);
         expect(out).toContain("already: true");
+        expect(out).toContain("ok: start cert-cleanup already in flight");
+        // Even on a no-op, the hint reflects the post-op state (done, not start).
+        expect(out).toContain("Run `tasks-axi done cert-cleanup --pr <url>`");
+      } finally {
+        b.cleanup();
+      }
+    });
+
+    it("emits a machine-readable task with --json", async () => {
+      const b = makeBacklog();
+      try {
+        const out = await startCommand(["cert-cleanup", "--json"], b.ctx);
+        const parsed = JSON.parse(out) as {
+          ok: boolean;
+          action: string;
+          task: { id: string; state: string };
+        };
+        expect(parsed.ok).toBe(true);
+        expect(parsed.action).toBe("start");
+        expect(parsed.task).toMatchObject({
+          id: "cert-cleanup",
+          state: "in_flight",
+        });
+        expect(out).not.toContain("help[");
       } finally {
         b.cleanup();
       }
@@ -79,11 +104,44 @@ describe("state commands", () => {
           ["cert-cleanup", "--pr", "https://github.com/o/r/pull/9", "--no-prune"],
           b.ctx,
         );
-        expect(out).toContain("state: done");
-        expect(out).toContain("pruned: 0");
+        expect(out).toContain(
+          "done cert-cleanup -> Done (pr https://github.com/o/r/pull/9)",
+        );
         const read = b.read();
         expect(read).toContain("https://github.com/o/r/pull/9");
         expect(read).toContain("(merged 2026-07-01)");
+      } finally {
+        b.cleanup();
+      }
+    });
+
+    it("emits a machine-readable task and pruned count with --json", async () => {
+      const b = makeBacklog();
+      try {
+        const out = await doneCommand(
+          [
+            "cert-cleanup",
+            "--pr",
+            "https://github.com/o/r/pull/9",
+            "--no-prune",
+            "--json",
+          ],
+          b.ctx,
+        );
+        const parsed = JSON.parse(out) as {
+          ok: boolean;
+          action: string;
+          pruned: number;
+          task: { id: string; state: string; links: { kind: string; url: string }[] };
+        };
+        expect(parsed.ok).toBe(true);
+        expect(parsed.action).toBe("done");
+        expect(parsed.pruned).toBe(0);
+        expect(parsed.task.state).toBe("done");
+        expect(parsed.task.links).toContainEqual({
+          kind: "pr",
+          url: "https://github.com/o/r/pull/9",
+        });
       } finally {
         b.cleanup();
       }
@@ -112,7 +170,7 @@ describe("state commands", () => {
         rmSync(archivePath, { recursive: true, force: true });
         const out = await doneCommand(["cert-cleanup", "--keep", "2"], b.ctx);
         expect(out).toContain("already: true");
-        expect(out).toContain("pruned: ");
+        expect(out).toMatch(/; pruned [1-9]/);
         expect(b.archive()).toContain("## Archived");
       } finally {
         b.cleanup();
@@ -262,7 +320,8 @@ describe("state commands", () => {
       const b = makeBacklog();
       try {
         const out = await reopenCommand(["lease-core-t4"], b.ctx);
-        expect(out).toContain("state: queued");
+        expect(out).toContain("ok: reopen lease-core-t4 -> Queued");
+        expect(out).toContain("Run `tasks-axi start lease-core-t4`");
       } finally {
         b.cleanup();
       }
@@ -289,7 +348,7 @@ describe("state commands", () => {
           ["cert-cleanup", "--by", "owns-widget-h7"],
           b.ctx,
         );
-        expect(added).toContain("blocked_by: owns-widget-h7");
+        expect(added).toContain("ok: block cert-cleanup -> blocked-by owns-widget-h7");
         expect(b.read()).toContain("blocked-by: owns-widget-h7");
 
         const again = await blockCommand(
@@ -297,13 +356,40 @@ describe("state commands", () => {
           b.ctx,
         );
         expect(again).toContain("already: true");
+        expect(again).toContain(
+          "ok: block cert-cleanup already blocked-by owns-widget-h7",
+        );
 
         const cleared = await unblockCommand(
           ["cert-cleanup", "--by", "owns-widget-h7"],
           b.ctx,
         );
         expect(cleared).not.toContain("already: true");
+        expect(cleared).toContain("ok: unblock cert-cleanup -> cleared owns-widget-h7");
         expect(b.read()).not.toContain("blocked-by: owns-widget-h7");
+      } finally {
+        b.cleanup();
+      }
+    });
+
+    it("emits a machine-readable task with --json", async () => {
+      const b = makeBacklog();
+      try {
+        const out = await blockCommand(
+          ["cert-cleanup", "--by", "owns-widget-h7", "--json"],
+          b.ctx,
+        );
+        const parsed = JSON.parse(out) as {
+          ok: boolean;
+          action: string;
+          blocked_by: string;
+          task: { id: string; blocked: boolean; blocked_by: string[] };
+        };
+        expect(parsed.ok).toBe(true);
+        expect(parsed.action).toBe("block");
+        expect(parsed.blocked_by).toBe("owns-widget-h7");
+        expect(parsed.task.blocked).toBe(true);
+        expect(parsed.task.blocked_by).toContain("owns-widget-h7");
       } finally {
         b.cleanup();
       }
@@ -440,8 +526,36 @@ describe("state commands", () => {
       const target = makeBacklog("# Backlog\n\n## In flight\n\n## Queued\n\n## Done\n");
       try {
         const out = await mvCommand(["cert-cleanup", "--to", target.path], b.ctx);
-        expect(out).toContain("moved:");
+        expect(out).toContain(`ok: mv cert-cleanup -> ${target.path}`);
         expect(b.read()).not.toContain("cert-cleanup");
+        expect(readFileSync(target.path, "utf8")).toContain("cert-cleanup");
+      } finally {
+        b.cleanup();
+        target.cleanup();
+      }
+    });
+
+    it("emits a machine-readable result with --json", async () => {
+      const b = makeBacklog();
+      const target = makeBacklog("# Backlog\n\n## Queued\n\n## Done\n");
+      try {
+        const out = await mvCommand(
+          ["cert-cleanup", "--to", target.path, "--json"],
+          b.ctx,
+        );
+        const parsed = JSON.parse(out) as {
+          ok: boolean;
+          action: string;
+          id: string;
+          from: string;
+          to: string;
+        };
+        expect(parsed).toMatchObject({
+          ok: true,
+          action: "mv",
+          id: "cert-cleanup",
+          to: target.path,
+        });
         expect(readFileSync(target.path, "utf8")).toContain("cert-cleanup");
       } finally {
         b.cleanup();

--- a/test/suggestions.test.ts
+++ b/test/suggestions.test.ts
@@ -58,6 +58,29 @@ describe("suggestions", () => {
     ]);
   });
 
+  it("never suggests start after an in-flight add (state-aware)", () => {
+    const lines = getSuggestions({ action: "add", id: "x-q1", state: "in_flight" });
+    expect(lines).toEqual([
+      "Run `tasks-axi done x-q1 --pr <url>` when it ships",
+      "Run `tasks-axi block x-q1 --by <other>` to record a dependency",
+    ]);
+    expect(lines.some((l) => l.includes("tasks-axi start"))).toBe(false);
+  });
+
+  it("suggests start after a queued add", () => {
+    const lines = getSuggestions({ action: "add", id: "x-q1", state: "queued" });
+    expect(lines).toContain(
+      "Run `tasks-axi start x-q1` to move it to in flight",
+    );
+  });
+
+  it("suggests reopen after re-adding a done task", () => {
+    const lines = getSuggestions({ action: "add", id: "x-q1", state: "done" });
+    expect(lines).toEqual([
+      "Run `tasks-axi reopen x-q1` to move it back to queued",
+    ]);
+  });
+
   it("carries repo scope into empty ready follow-ups", () => {
     const lines = getSuggestions({
       action: "ready",

--- a/test/suggestions.test.ts
+++ b/test/suggestions.test.ts
@@ -59,7 +59,11 @@ describe("suggestions", () => {
   });
 
   it("never suggests start after an in-flight add (state-aware)", () => {
-    const lines = getSuggestions({ action: "add", id: "x-q1", state: "in_flight" });
+    const lines = getSuggestions({
+      action: "add",
+      id: "x-q1",
+      state: "in_flight",
+    });
     expect(lines).toEqual([
       "Run `tasks-axi done x-q1 --pr <url>` when it ships",
       "Run `tasks-axi block x-q1 --by <other>` to record a dependency",
@@ -68,7 +72,11 @@ describe("suggestions", () => {
   });
 
   it("suggests start after a queued add", () => {
-    const lines = getSuggestions({ action: "add", id: "x-q1", state: "queued" });
+    const lines = getSuggestions({
+      action: "add",
+      id: "x-q1",
+      state: "queued",
+    });
     expect(lines).toContain(
       "Run `tasks-axi start x-q1` to move it to in flight",
     );


### PR DESCRIPTION
## Intent

Improve tasks-axi's WRITE-operation output (real dogfooding feedback from firstmate, which drives its backlog through tasks-axi) so a mutation confirms what it did, not just what to do next. The READ side (list/ready/show) was already good; the gap was the mutation verbs.

Three concrete fixes: (1) every mutation verb (add/start/done/reopen/update/rm/block/unblock/mv/prune/render) now leads with a terse 'ok: <verb> <id> ... -> <Resulting State>' confirmation line (e.g. 'ok: added grok-harness-g7 (ship, repo firstmate) -> In flight', 'ok: done X -> Done (pr <url>)'). (2) State-aware hints: the post-op suggestions are no longer a generic template and never suggest an action the command just performed - this fixes the clearest reported bug where 'add <id> ... --start' still printed 'Run tasks-axi start <id>' even though --start already moved it to In flight. 'add' now branches its hint on resulting state (in_flight->suggest done, queued->suggest start, done->suggest reopen). (3) Added a --json flag to every mutation for a deterministic machine-readable result object ({ ok:true, action, [already], task|id|..., ... }) so an agent can confirm a write without a follow-up read; human-readable TOON stays the default.

Key decisions/tradeoffs: This is OUTPUT-ONLY by design - the backlog.md format/contract (## In flight / ## Queued / ## Done sections, '- [ ]'/'- [x]' checkboxes, 'blocked-by: <id> - <reason>') is deliberately untouched; markdown-grammar.ts and markdown.ts were not modified. I replaced the small redundant per-verb detail blocks (e.g. start:/done:/block:/moved:) with the terse 'ok:' line for token-cheapness, but KEPT the full field-tagged 'task:' detail for add/update since those produce/modify a rich record worth showing. The 'ok:' line is emitted as a PLAIN top-level TOON scalar ('ok: <message>') rather than via encode(), deliberately, so it stays readable and unquoted; I verified it still round-trips through TOON decode() even with commas/colons (confirmation messages are built only from bounded values: ids, names, validated urls/paths, counts). Errors intentionally stay in the existing structured-error + non-zero-exit form under --json (not JSON), so exit 0 + ok:true is the success signal. New src/confirm.ts owns the ok-line, the --json payload (taskToJson), and renderMutation (assembles both); suggestions became state-aware via a new SuggestionContext.state field. Followed the AXI skill standards and matched tasks-axi's existing conventions. Documented --json and the confirmation convention in per-command help, the generated SKILL.md (regenerated, not hand-edited), README, and AGENTS.md. Added/extended tests for the confirmation text, the state-aware hints (incl. the add --start case), and the --json output. Conventional 'feat:' commit so release-please picks it up; did not hand-bump the version.

## What Changed

- Added confirmation-forward output for mutation commands so write operations lead with an `ok:` result line, while preserving richer `task:` details for add/update.
- Added `--json` support for mutations with deterministic success payloads, alongside state-aware hints that reflect the resulting task state.
- Updated command help, README, generated skill docs, and focused command/suggestion tests to cover the new mutation output behavior.

## Risk Assessment

✅ Low: The branch is a well-bounded output-only mutation rendering change with centralized helpers and no material correctness, security, or compatibility issues found in the reviewed diff.

## Testing

The automated mutation-output tests passed, the actual CLI was exercised end to end on a firstmate-shaped markdown backlog, reviewer-visible evidence was captured for human TOON confirmations, state-aware hints, `--json`, persisted backlog state, move output, and prune archive output, and transient dependency artifacts were cleaned up.

- Evidence: [CLI mutation transcript](https://github.com/kunchenguid/tasks-axi/blob/91661329e62ddd45d349c2de3057dd50c81383d6/.no-mistakes/evidence/fm/tasks-axi-confirm-w5/cli-mutation-transcript.txt)
- Evidence: [Final source backlog state](https://github.com/kunchenguid/tasks-axi/blob/91661329e62ddd45d349c2de3057dd50c81383d6/.no-mistakes/evidence/fm/tasks-axi-confirm-w5/e2e-backlog.md)
- Evidence: [Moved-task destination backlog](https://github.com/kunchenguid/tasks-axi/blob/91661329e62ddd45d349c2de3057dd50c81383d6/.no-mistakes/evidence/fm/tasks-axi-confirm-w5/e2e-destination.md)
- Evidence: [Pruned done-task archive](https://github.com/kunchenguid/tasks-axi/blob/91661329e62ddd45d349c2de3057dd50c81383d6/.no-mistakes/evidence/fm/tasks-axi-confirm-w5/done-archive.md)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `pnpm test -- test/commands/crud.test.ts test/commands/state.test.ts test/commands/maintain.test.ts test/cli.test.ts test/suggestions.test.ts`
- `pnpm --silent dev list --file test/fixtures/firstmate-backlog.md`
- <code>Generated `.no-mistakes/evidence/fm/tasks-axi-confirm-w5/cli-mutation-transcript.txt` by running real `pnpm --silent dev` mutation commands for add/start/done/reopen/update/rm/block/unblock/mv/prune/render against `.no-mistakes/evidence/fm/tasks-axi-confirm-w5/e2e-backlog.md`.</code>
- <code>Inspected the transcript and persisted markdown files with `sed`; ran a scoped `awk`/`rg` assertion confirming the `add --start` block suggests `done` and does not suggest `start`, and that the transcript includes JSON `ok: true`, mv/render confirmations, prune archive output, and the archived markdown state.</code>
- <code>Removed transient `node_modules` created by the test install and confirmed `git status --short --ignored` only shows the intended evidence directory.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
