### PR TITLE
fix(config): discover .tasks.toml up the tree; fail loud when no ledger found

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,7 @@ The CLI layer never knows which backend is active — it only talks to the `Stor
 
 - `src/cli.ts` — `runAxiCli` wiring: `DESCRIPTION`, `TOP_HELP`, the verb→handler map (with aliases create/view/edit/delete/close), the optional `task` noun prefix, and the global `--backend` / `--file` flags (stripped before handlers, parsed for `resolveContext`).
 - `src/context.ts` — `resolveTasksContext` builds the backend `Store` + `ResolvedConfig`; every command receives this `TasksContext`.
+- `src/config.ts` — backend/path resolution. `.tasks.toml` is discovered git-style (walk up from cwd to the nearest ancestor holding one, so verbs run from a subdirectory hit the project's real ledger; relative config paths anchor at the directory holding the config, not cwd). With no anchor at all — no config, no `--file`/`TASKS_AXI_FILE`, no conventional `backlog.md`/`data/backlog.md` anywhere up the tree — resolution fails loudly (`NOT_FOUND`) instead of silently creating a stray `backlog.md` in cwd.
 - `src/store.ts` — the `Store` interface and `Capabilities`. Core contract: `create/get/update/remove/list/transition/addDep/removeDep`. `prune`/`render` are optional and capability-gated.
 - `src/model.ts` — the `Task` data model (report §5).
 - `src/derive.ts` — `blocked` / `ready` / active `held` are derived in the CLI from `list` + the dep graph + hold date gates, never Store methods, so every backend gets them for free.

--- a/README.md
+++ b/README.md
@@ -176,8 +176,10 @@ Single-task `mv` has the same protection; use multi-task `mv` to move its active
 
 ## Configuration
 
-Backend and path are resolved in this order: `--backend` / `--file` flags passed after the command, then `TASKS_AXI_BACKEND` / `TASKS_AXI_FILE` env, then a project `.tasks.toml`, then `~/.tasks-axi/config.toml`, then the defaults.
-Without an explicit path, tasks-axi uses `backlog.md` when present, then `data/backlog.md` when present, and otherwise targets `backlog.md` for future writes.
+Backend and path are resolved in this order: `--backend` / `--file` flags passed after the command, then `TASKS_AXI_BACKEND` / `TASKS_AXI_FILE` env, then a project `.tasks.toml`, then `~/.tasks-axi/config.toml`, then a conventional backlog found up the tree.
+The project `.tasks.toml` is discovered git-style: tasks-axi walks up from the current directory to the nearest ancestor that holds one, so verbs run from a subdirectory resolve against the project's real ledger (relative paths in that config anchor at the directory holding it, not the current directory).
+Without an explicit path or config, tasks-axi adopts a `backlog.md` (then `data/backlog.md`) found in the current directory or any parent.
+If nothing anchors a ledger — no config, no `--file`/env override, and no conventional backlog anywhere up the tree — tasks-axi fails loudly rather than silently creating a stray `backlog.md` in the current directory. Point it at a ledger with `--file`/`TASKS_AXI_FILE`, or add a `.tasks.toml` at your project root.
 
 ```toml
 # .tasks.toml in the project root

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,6 @@
 import { existsSync } from "node:fs";
 import { homedir } from "node:os";
-import { isAbsolute, join, resolve } from "node:path";
+import { dirname, isAbsolute, join, resolve } from "node:path";
 import { readFileSafe } from "./backends/lock.js";
 import { AxiError } from "./errors.js";
 
@@ -9,8 +9,15 @@ import { AxiError } from "./errors.js";
  *
  * Override order:
  *   --backend / --file flag > TASKS_AXI_* env > project .tasks.toml >
- *   ~/.tasks-axi/config.toml > defaults (markdown, first existing
- *   backlog.md/data/backlog.md, otherwise backlog.md).
+ *   ~/.tasks-axi/config.toml > first existing backlog.md/data/backlog.md
+ *   found walking up from cwd.
+ *
+ * `.tasks.toml` is discovered git-style: we walk up from cwd to the nearest
+ * ancestor holding one, so verbs run from a subdirectory resolve against the
+ * project's real ledger instead of the current directory. When nothing
+ * anchors a ledger (no config, no override, no conventional backlog anywhere
+ * up the tree) resolution fails loudly rather than silently creating a stray
+ * backlog.md in cwd.
  *
  * P1 ships only the markdown backend; the Store seam keeps sqlite/remote
  * additions invisible to the CLI layer.
@@ -161,19 +168,91 @@ function loadToml(path: string): TomlConfig {
   return src ? parseConfigToml(src) : {};
 }
 
-function resolveMarkdownPath(
-  explicit: string | undefined,
-  tomlPath: string | undefined,
-  cwd: string,
-): string {
-  const chosen = explicit ?? tomlPath;
-  if (chosen) return isAbsolute(chosen) ? chosen : resolve(cwd, chosen);
+/**
+ * Walk up from `startDir` to the filesystem root, returning the first ancestor
+ * directory (inclusive) that contains a file named `name`, or undefined.
+ */
+function findUp(startDir: string, name: string): string | undefined {
+  let dir = resolve(startDir);
+  for (;;) {
+    if (existsSync(join(dir, name))) return dir;
+    const parent = dirname(dir);
+    if (parent === dir) return undefined;
+    dir = parent;
+  }
+}
 
+/** The first conventional backlog candidate present directly in `dir`. */
+function backlogAt(dir: string): string | undefined {
   for (const candidate of PATH_CANDIDATES) {
-    const full = resolve(cwd, candidate);
+    const full = join(dir, candidate);
     if (existsSync(full)) return full;
   }
-  return resolve(cwd, PATH_CANDIDATES[0]);
+  return undefined;
+}
+
+/** Walk up from `startDir` to the first existing conventional backlog file. */
+function findBacklogUp(startDir: string): string | undefined {
+  let dir = resolve(startDir);
+  for (;;) {
+    const found = backlogAt(dir);
+    if (found) return found;
+    const parent = dirname(dir);
+    if (parent === dir) return undefined;
+    dir = parent;
+  }
+}
+
+interface PathSources {
+  explicitPath: string | undefined;
+  projectPath: string | undefined;
+  projectRoot: string | undefined;
+  homePath: string | undefined;
+  cwd: string;
+}
+
+/**
+ * Resolve the markdown ledger path, throwing when nothing anchors a ledger.
+ *
+ * Order: explicit --file/env > project `.tasks.toml` markdown.path (relative to
+ * the discovered project root) > home config markdown.path > an existing
+ * backlog beside a discovered `.tasks.toml` or anywhere up from cwd. With no
+ * anchor at all we refuse rather than silently forking a new backlog in cwd.
+ */
+function resolveMarkdownPath(sources: PathSources): string {
+  const { explicitPath, projectPath, projectRoot, homePath, cwd } = sources;
+
+  if (explicitPath !== undefined) {
+    return isAbsolute(explicitPath) ? explicitPath : resolve(cwd, explicitPath);
+  }
+  if (projectPath !== undefined) {
+    return isAbsolute(projectPath)
+      ? projectPath
+      : resolve(projectRoot ?? cwd, projectPath);
+  }
+  if (homePath !== undefined) {
+    return isAbsolute(homePath) ? homePath : resolve(cwd, homePath);
+  }
+
+  // A discovered `.tasks.toml` without an explicit path anchors the ledger at
+  // the project root: reuse a backlog already sitting there, else default to
+  // creating one there (safe — the config declares this is the project).
+  if (projectRoot !== undefined) {
+    return backlogAt(projectRoot) ?? join(projectRoot, PATH_CANDIDATES[0]);
+  }
+
+  // No config: adopt a conventional backlog found anywhere up from cwd.
+  const existing = findBacklogUp(cwd);
+  if (existing !== undefined) return existing;
+
+  throw new AxiError(
+    "No tasks-axi ledger found here or in any parent directory",
+    "NOT_FOUND",
+    [
+      "Run tasks-axi from your project root, or add a `.tasks.toml` there",
+      "Point at a ledger explicitly with `--file <path>` or `TASKS_AXI_FILE`",
+    ],
+  );
 }
 
 function validatePathValue(
@@ -206,7 +285,13 @@ export function resolveConfig(overrides: ConfigOverrides = {}): ResolvedConfig {
   const home = overrides.home ?? homedir();
 
   const homeToml = loadToml(join(home, ".tasks-axi", "config.toml"));
-  const projectToml = loadToml(resolve(cwd, ".tasks.toml"));
+  // Git-style discovery: the nearest `.tasks.toml` walking up from cwd anchors
+  // the project, so verbs run from a subdirectory hit its real ledger.
+  const projectRoot = findUp(cwd, ".tasks.toml");
+  const projectToml =
+    projectRoot !== undefined
+      ? loadToml(join(projectRoot, ".tasks.toml"))
+      : {};
 
   const explicitPath =
     overrides.file !== undefined
@@ -214,12 +299,14 @@ export function resolveConfig(overrides: ConfigOverrides = {}): ResolvedConfig {
       : env.TASKS_AXI_FILE !== undefined
         ? validatePathValue(env.TASKS_AXI_FILE, "TASKS_AXI_FILE")
         : undefined;
-  const tomlPath =
+  const projectPath =
     explicitPath !== undefined
       ? undefined
-      : projectToml.markdown?.path !== undefined
-        ? validatePathValue(projectToml.markdown.path, "markdown.path")
-        : validatePathValue(homeToml.markdown?.path, "markdown.path");
+      : validatePathValue(projectToml.markdown?.path, "markdown.path");
+  const homePath =
+    explicitPath !== undefined || projectPath !== undefined
+      ? undefined
+      : validatePathValue(homeToml.markdown?.path, "markdown.path");
 
   const backend =
     overrides.backend ??
@@ -228,12 +315,26 @@ export function resolveConfig(overrides: ConfigOverrides = {}): ResolvedConfig {
     homeToml.backend ??
     "markdown";
 
-  const path = resolveMarkdownPath(explicitPath, tomlPath, cwd);
+  const path = resolveMarkdownPath({
+    explicitPath,
+    projectPath,
+    projectRoot,
+    homePath,
+    cwd,
+  });
 
+  // Relative archive paths anchor where their config lives: the project root
+  // for a discovered `.tasks.toml`, else cwd for the home default.
+  const projectArchive = validatePathValue(
+    projectToml.markdown?.archive,
+    "markdown.archive",
+  );
   const archive =
-    projectToml.markdown?.archive !== undefined
-      ? validatePathValue(projectToml.markdown.archive, "markdown.archive")
+    projectArchive !== undefined
+      ? projectArchive
       : validatePathValue(homeToml.markdown?.archive, "markdown.archive");
+  const archiveBase =
+    projectArchive !== undefined ? (projectRoot ?? cwd) : cwd;
   const doneKeep = validateDoneKeep(
     projectToml.markdown?.done_keep ??
       homeToml.markdown?.done_keep ??
@@ -242,7 +343,9 @@ export function resolveConfig(overrides: ConfigOverrides = {}): ResolvedConfig {
 
   const config: ResolvedConfig = { backend, path, doneKeep };
   if (archive) {
-    config.archivePath = isAbsolute(archive) ? archive : resolve(cwd, archive);
+    config.archivePath = isAbsolute(archive)
+      ? archive
+      : resolve(archiveBase, archive);
   }
   return config;
 }

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -1,4 +1,11 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -83,7 +90,15 @@ describe("parseConfigToml", () => {
 });
 
 describe("resolveConfig", () => {
-  it("defaults to the markdown backend and backlog.md", () => {
+  it("fails loudly and creates nothing when no ledger is found up the tree", () => {
+    expect(() => resolveConfig({ cwd: dir, home, env: {} })).toThrow(
+      /No tasks-axi ledger found/,
+    );
+    expect(readdirSync(dir)).toEqual([]);
+  });
+
+  it("adopts an existing backlog.md in cwd without a config file", () => {
+    writeFileSync(join(dir, "backlog.md"), "# Backlog\n");
     const cfg = resolveConfig({ cwd: dir, home, env: {} });
     expect(cfg.backend).toBe("markdown");
     expect(cfg.path).toBe(join(dir, "backlog.md"));
@@ -96,6 +111,39 @@ describe("resolveConfig", () => {
     writeFileSync(join(data, "backlog.md"), "# Backlog\n");
     const cfg = resolveConfig({ cwd: dir, home, env: {} });
     expect(cfg.path).toBe(join(data, "backlog.md"));
+  });
+
+  it("discovers a parent .tasks.toml when run from a subdirectory", () => {
+    writeFileSync(
+      join(dir, ".tasks.toml"),
+      'backend = "markdown"\n[markdown]\npath = "data/backlog.md"\narchive = "data/done-archive.md"\n',
+    );
+    const sub = join(dir, "deep", "nested");
+    mkdirSync(sub, { recursive: true });
+
+    const cfg = resolveConfig({ cwd: sub, home, env: {} });
+    // The relative path anchors at the project root, not the subdirectory.
+    expect(cfg.path).toBe(join(dir, "data", "backlog.md"));
+    expect(cfg.archivePath).toBe(join(dir, "data", "done-archive.md"));
+    // No stray ledger is planted in the subdirectory we were invoked from.
+    expect(existsSync(join(sub, "backlog.md"))).toBe(false);
+  });
+
+  it("adopts a parent backlog.md from a subdirectory without a config file", () => {
+    writeFileSync(join(dir, "backlog.md"), "# Backlog\n");
+    const sub = join(dir, "deep");
+    mkdirSync(sub, { recursive: true });
+    const cfg = resolveConfig({ cwd: sub, home, env: {} });
+    expect(cfg.path).toBe(join(dir, "backlog.md"));
+  });
+
+  it("anchors a pathless .tasks.toml ledger at the project root from a subdir", () => {
+    writeFileSync(join(dir, ".tasks.toml"), "[markdown]\ndone_keep = 5\n");
+    const sub = join(dir, "deep");
+    mkdirSync(sub, { recursive: true });
+    const cfg = resolveConfig({ cwd: sub, home, env: {} });
+    expect(cfg.path).toBe(join(dir, "backlog.md"));
+    expect(cfg.doneKeep).toBe(5);
   });
 
   it("honors the override order: flag > env > project toml", () => {


### PR DESCRIPTION
## Problem

`tasks-axi` resolves its `.tasks.toml` config and conventional backlog **only from the current working directory** — it never walks up parent directories. And when it finds no config and no backlog, it silently defaults to `resolve(cwd, "backlog.md")` for future writes.

The result: run any write verb from a subdirectory (or an unrelated directory) and `tasks-axi add` **silently creates a stray `backlog.md` ledger in that cwd** instead of hitting the project's real backlog. Later verbs run from the project root then report the just-added task as `NOT_FOUND`. In practice this silently forks a task ledger — it bit us twice in one day.

### Reproduction (before this PR)

```sh
mkdir -p proj/deep/sub
printf 'backend = "markdown"\n[markdown]\npath = "backlog.md"\n' > proj/.tasks.toml
printf '# Backlog\n\n## Queued\n\n- [ ] real-1 - the real task\n' > proj/backlog.md

cd proj/deep/sub
tasks-axi add stray-1 "added from a subdirectory"
# ok: added stray-1 -> Queued        <-- looks fine
ls                                     # -> backlog.md   <-- STRAY ledger created here!

cd ../../                              # the real project root
tasks-axi show stray-1
# error: Task "stray-1" not found in this backlog   <-- forked
```

Why silent creation is dangerous: nothing about the successful `ok:` line tells you the write landed in the wrong file. The ledger diverges invisibly, and the divergence is only discovered later when a lookup from the right directory fails.

## Change

Two focused changes in `src/config.ts`:

1. **Git-style discovery.** Walk up from cwd to the nearest ancestor that holds a `.tasks.toml` and treat that directory as the project root. Relative config paths (`markdown.path`, `markdown.archive`) now anchor at the directory holding the config, not cwd — so verbs run from anywhere inside a project resolve against the project's real ledger. An existing conventional `backlog.md` / `data/backlog.md` is likewise adopted from cwd or any parent.

2. **Fail loud instead of silently forking.** When *nothing* anchors a ledger — no `.tasks.toml` anywhere up the tree, no `--file` / `TASKS_AXI_FILE` override, and no conventional backlog up the tree — resolution now throws a clear `NOT_FOUND` error (non-zero exit, creates nothing) instead of defaulting to `cwd/backlog.md`:

   ```
   error: No tasks-axi ledger found here or in any parent directory
   code: NOT_FOUND
   help: Run tasks-axi from your project root, or add a `.tasks.toml` there
   help: Point at a ledger explicitly with `--file <path>` or `TASKS_AXI_FILE`
   ```

The precedence order is unchanged for cases that already resolved: `--file`/env > project `.tasks.toml` > `~/.tasks-axi/config.toml` > an existing conventional backlog. Explicit `--file`/`TASKS_AXI_FILE` still wins and never fails, so scripted/CI usage is unaffected. The zero-config "just a `backlog.md` in my repo" workflow keeps working (and now works from subdirectories too).

### ⚠️ Deliberate behavior change

The **no-config case** is an intentional behavior change: previously `resolveConfig` returned `cwd/backlog.md` and the next write created it; now it fails loudly. This is the whole point of the fix — silent ledger creation in the wrong directory is the bug. If you'd prefer implicit ledger creation to remain possible, it could be gated behind an explicit flag or an `init` verb; happy to adjust. The one existing test that enshrined the silent default is updated to assert the new fail-loud behavior.

## Tests

Added to `test/config.test.ts`:
- run-from-a-subdirectory discovers the parent `.tasks.toml`, resolves `path`/`archive` against the project root, and plants **no** stray ledger in the subdirectory;
- run-from-a-subdirectory adopts a parent `backlog.md` with no config file;
- a pathless `.tasks.toml` anchors the ledger at the project root from a subdir;
- run-from-nowhere (no config, no backlog up the tree) throws `NOT_FOUND` and **creates nothing** (asserts the directory stays empty);
- the existing "adopts an existing backlog.md in cwd" / "prefers data/backlog.md" cases still pass.

Full suite: **354 passed, 1 skipped**. `pnpm lint` clean; `pnpm run build:skill -- --check` reports no drift. README config section and `AGENTS.md` updated to document discovery + fail-loud.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
