### PR TITLE
feat(mv): add atomic state precondition

### DIFF
--- a/src/backends/markdown.ts
+++ b/src/backends/markdown.ts
@@ -818,7 +818,11 @@ export class MarkdownStore implements Store {
    * endpoints travel together; `requireNoSplitDeps` refuses any move that would
    * strand a link across the two files.
    */
-  async moveManyTo(ids: string[], target: MarkdownStore): Promise<Task[]> {
+  async moveManyTo(
+    ids: string[],
+    target: MarkdownStore,
+    options: { requiredState?: State } = {},
+  ): Promise<Task[]> {
     const uniqueIds = [...new Set(ids)];
     return withLocks([this.path, target.path], () => {
       const loaded = this.loadForUpdate();
@@ -831,6 +835,17 @@ export class MarkdownStore implements Store {
         if (!found) throw new AxiError(`Task "${id}" not found`, "NOT_FOUND");
         return found;
       });
+
+      if (options.requiredState !== undefined) {
+        for (const found of founds) {
+          if (found.entry.task.state !== options.requiredState) {
+            throw new AxiError(
+              `Task "${found.entry.task.id}" has state "${found.entry.task.state}"; move requires state "${options.requiredState}"`,
+              "VALIDATION_ERROR",
+            );
+          }
+        }
+      }
 
       const targetLoaded = target.loadForUpdate();
       const { doc: targetDoc } = targetLoaded;

--- a/src/commands/state.ts
+++ b/src/commands/state.ts
@@ -3,6 +3,7 @@ import { existsSync, statSync } from "node:fs";
 import { MarkdownStore } from "../backends/markdown.js";
 import {
   parseNonNegativeIntegerFlag,
+  parseStateFlag,
   requireNoUnknownFlags,
   requireNonEmptyFlagValue,
   requireNonEmptySingleLineFlagValue,
@@ -107,10 +108,13 @@ Duplicate ids are ignored after their first occurrence.
 Refuses if a moved item's dependency or active dependent would be stranded in the other
 file - include the whole set, or move the missing endpoint there first.
 flags:
+  --require-state queued|in_flight|done
+           atomically refuse unless every moved task is still in this state
   --json   print the result as a JSON object
 examples:
   tasks-axi mv hibit-cert-cleanup --to ../homemux/data/backlog.md
-  tasks-axi mv blocker-b1 dependent-d2 --to ../homemux/data/backlog.md`;
+  tasks-axi mv blocker-b1 dependent-d2 --to ../homemux/data/backlog.md
+  tasks-axi mv queued-a queued-b --to ../other/backlog.md --require-state queued`;
 
 export async function startCommand(
   rawArgs: string[],
@@ -683,6 +687,10 @@ export async function mvCommand(
   const args = [...rawArgs];
 
   const json = takeBoolFlag(args, "--json");
+  const requiredState = parseStateFlag(
+    "--require-state",
+    takeFlag(args, "--require-state"),
+  );
   const to = requireNonEmptySingleLineFlagValue("--to", takeFlag(args, "--to"));
   if (to === undefined) {
     throw new AxiError("--to <path-or-dir> is required", "VALIDATION_ERROR", [
@@ -724,7 +732,12 @@ export async function mvCommand(
   }
 
   if (store instanceof MarkdownStore) {
-    await store.moveManyTo(ids, target);
+    await store.moveManyTo(ids, target, { requiredState });
+  } else if (requiredState !== undefined) {
+    throw new AxiError(
+      "--require-state requires the markdown backend",
+      "UNSUPPORTED",
+    );
   } else if (ids.length === 1) {
     await target.create(taskToInput(tasks[0]));
     await store.remove(ids[0]);

--- a/test/backends/markdown.test.ts
+++ b/test/backends/markdown.test.ts
@@ -1236,6 +1236,40 @@ describe("MarkdownStore", () => {
       }
     });
 
+    it("atomically refuses a mixed-state set under requiredState", async () => {
+      const sourceText = [
+        "# Backlog",
+        "",
+        "## In flight",
+        "- [ ] active-a - already active",
+        "",
+        "## Queued",
+        "- [ ] queued-b - still queued",
+        "",
+        "## Done",
+        "",
+      ].join("\n");
+      const source = makeBacklog(sourceText);
+      const target = makeBacklog("# Backlog\n\n## Queued\n\n## Done\n");
+      const sourceBefore = source.read();
+      const targetBefore = target.read();
+      try {
+        await expect(
+          source.store.moveManyTo(["active-a", "queued-b"], target.store, {
+            requiredState: "queued",
+          }),
+        ).rejects.toMatchObject({
+          code: "VALIDATION_ERROR",
+          message: expect.stringContaining('requires state "queued"'),
+        });
+        expect(source.read()).toBe(sourceBefore);
+        expect(target.read()).toBe(targetBefore);
+      } finally {
+        source.cleanup();
+        target.cleanup();
+      }
+    });
+
     it("rolls back every created destination task when source removal fails", async () => {
       const source = makeBacklog(linkedSet);
       const target = makeBacklog("# Backlog\n\n## Queued\n\n## Done\n");

--- a/test/commands/state.test.ts
+++ b/test/commands/state.test.ts
@@ -879,6 +879,93 @@ describe("state commands", () => {
       }
     });
 
+    it("revalidates --require-state inside the locked move transaction", async () => {
+      const b = makeBacklog(
+        "# Backlog\n\n## Queued\n- [ ] race-q1 - queued before lock\n\n## Done\n",
+      );
+      const target = makeBacklog("# Backlog\n\n## Queued\n\n## Done\n");
+      const originalGet = b.store.get.bind(b.store);
+      let edited = false;
+      b.store.get = async (taskId: string) => {
+        const task = await originalGet(taskId);
+        if (taskId === "race-q1" && !edited) {
+          edited = true;
+          writeFileSync(
+            b.path,
+            "# Backlog\n\n## In flight\n- [ ] race-q1 - changed after advisory read\n\n## Queued\n\n## Done\n",
+            "utf8",
+          );
+        }
+        return task;
+      };
+      const sourceBeforeMove = () => b.read();
+      try {
+        await expect(
+          mvCommand(
+            ["race-q1", "--to", target.path, "--require-state", "queued"],
+            b.ctx,
+          ),
+        ).rejects.toMatchObject({
+          code: "VALIDATION_ERROR",
+          message: expect.stringContaining('requires state "queued"'),
+        });
+        expect(edited).toBe(true);
+        expect(sourceBeforeMove()).toContain("## In flight");
+        expect(sourceBeforeMove()).toContain("race-q1");
+        expect(readFileSync(target.path, "utf8")).not.toContain("race-q1");
+      } finally {
+        b.cleanup();
+        target.cleanup();
+      }
+    });
+
+    it("rejects an invalid --require-state before moving", async () => {
+      const b = makeBacklog();
+      const target = makeBacklog("# Backlog\n\n## Queued\n\n## Done\n");
+      const sourceBefore = b.read();
+      const targetBefore = target.read();
+      try {
+        await expect(
+          mvCommand(
+            ["cert-cleanup", "--to", target.path, "--require-state", "blocked"],
+            b.ctx,
+          ),
+        ).rejects.toMatchObject({ code: "VALIDATION_ERROR" });
+        expect(b.read()).toBe(sourceBefore);
+        expect(target.read()).toBe(targetBefore);
+      } finally {
+        b.cleanup();
+        target.cleanup();
+      }
+    });
+
+    it("moves every queued member with --require-state queued", async () => {
+      const source = [
+        "# Backlog",
+        "",
+        "## Queued",
+        "- [ ] pair-a - first",
+        "- [ ] pair-b - second blocked-by: pair-a",
+        "",
+        "## Done",
+        "",
+      ].join("\n");
+      const b = makeBacklog(source);
+      const target = makeBacklog("# Backlog\n\n## Queued\n\n## Done\n");
+      try {
+        await mvCommand(
+          ["pair-a", "pair-b", "--to", target.path, "--require-state=queued"],
+          b.ctx,
+        );
+        expect(b.read()).not.toContain("pair-a");
+        expect(readFileSync(target.path, "utf8")).toContain("pair-a");
+        expect(readFileSync(target.path, "utf8")).toContain("pair-b");
+      } finally {
+        b.cleanup();
+        target.cleanup();
+      }
+    });
+
     it("leaves the source intact when destination validation fails", async () => {
       const b = makeBacklog(
         "# Backlog\n\n## Queued\n- [ ] bad-q1 - invalid parsed repo (repo: foo(bar)\n\n## Done\n",


### PR DESCRIPTION
## Summary

Add an optional atomic state precondition to `tasks-axi mv`:

```sh
tasks-axi mv task-a task-b --to ../other/backlog.md --require-state queued
```

When supplied, every selected source task is revalidated against the requested state inside the existing two-file `withLocks` transaction. A mismatch refuses the entire move before either backlog is written.

## Why

Callers that delegate only queued work otherwise have a TOCTOU gap: they can inspect a task as queued, but its state may change before `mv` acquires the source/destination locks. The current `mv` command correctly provides an atomic cross-file move, but it intentionally accepts tasks in any state.

This capability is needed by munsu's secondmate handoff contract, which must never transfer in-flight or completed work.

## Compatibility

- Existing `mv` behavior is unchanged when `--require-state` is omitted.
- Supported values use the existing state vocabulary: `queued`, `in_flight`, `done`.
- Non-markdown backends fail closed when the precondition is requested because they cannot provide the same transaction guarantee.

## Verification

- Race regression: state changes after the CLI's advisory read but before the locked move; the locked precondition refuses it.
- Mixed-state multi-item move refuses byte-preservingly for both files.
- Valid connected queued set moves successfully.
- Invalid state flag refuses before mutation.
- Full repository: 384 tests pass (1 existing skip).
- `pnpm build`, `pnpm lint`, and generated-skill check pass.
- no-mistakes completed intent, rebase, review, test, document, and lint with zero findings; its direct upstream push failed only because the authenticated contributor lacks write access, so this fork PR was opened manually.
