### PR TITLE
fix: execute every PR body compliance event

### DIFF
--- a/.github/workflows/no-mistakes-required.yml
+++ b/.github/workflows/no-mistakes-required.yml
@@ -1,4 +1,5 @@
 name: Require no-mistakes
+run-name: "PR #${{ github.event.pull_request.number }} body compliance - ${{ github.event.action }} - event ${{ github.run_number }} (run ${{ github.run_id }})"
 
 on:
   pull_request:
@@ -9,8 +10,12 @@ on:
 permissions:
   contents: read
 
+# GitHub concurrency groups retain at most one pending run, replacing older
+# pending runs even when cancel-in-progress is false. Give body-bearing events
+# an immutable per-event group so first-time-fork approvals can never collapse
+# opened/edited checks. Keep synchronize/reopened coalescing as before.
 concurrency:
-  group: no-mistakes-required-${{ github.event.pull_request.number }}
+  group: no-mistakes-required-${{ github.event.pull_request.number }}-${{ (github.event.action == 'opened' || github.event.action == 'edited') && github.run_id || 'head-change' }}
   cancel-in-progress: true
 
 jobs:

--- a/.no-mistakes/evidence/fm/nm-body-events-tasks-axi-r1/workflow-acceptance.txt
+++ b/.no-mistakes/evidence/fm/nm-body-events-tasks-axi-r1/workflow-acceptance.txt
@@ -1,0 +1,62 @@
+tasks-axi no-mistakes workflow acceptance
+
+PASS: committed scope is only the required workflow
+PASS: the workflow change contains exactly two hunks
+PASS: YAML syntax parses
+PASS: canonical run-name is exact
+PASS: opened/edited use run_id while head changes coalesce
+PASS: cancel-in-progress remains true
+PASS: pull_request trigger and event set are preserved
+PASS: main branch filter is preserved
+PASS: permissions remain contents read-only
+PASS: workflow does not use pull_request_target
+PASS: workflow does not reference secrets
+PASS: workflow does not check out or execute fork code
+PASS: stable check name is preserved
+PASS: github-actions[bot] exemption is preserved
+PASS: dependabot[bot] exemption is preserved
+PASS: release-please[bot] exemption is preserved
+PASS: signature marker is preserved exactly
+
+Resolved run identities
+unsigned opened:
+  group: no-mistakes-required-42-9001
+  run-name: PR #42 body compliance - opened - event 301 (run 9001)
+signed edited:
+  group: no-mistakes-required-42-9002
+  run-name: PR #42 body compliance - edited - event 302 (run 9002)
+signed same-head replay:
+  group: no-mistakes-required-42-9003
+  run-name: PR #42 body compliance - edited - event 303 (run 9003)
+synchronize:
+  group: no-mistakes-required-42-head-change
+  run-name: PR #42 body compliance - synchronize - event 304 (run 9004)
+reopened:
+  group: no-mistakes-required-42-head-change
+  run-name: PR #42 body compliance - reopened - event 305 (run 9005)
+PASS: opened, edited, and same-head replay cannot collapse
+PASS: synchronize and reopened retain head-change coalescing
+
+unsigned opened body: exit 1
+::error::This PR was not raised through no-mistakes.
+
+Contributions to this repository must be submitted via 'git push no-mistakes'.
+That pipeline runs the required review/test/lint/CI steps and writes a
+deterministic '## Pipeline' section into the PR body containing:
+
+    Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)
+
+See CONTRIBUTING.md for setup and the full workflow.
+
+PR author: contributor
+
+signed edited body: exit 0
+Found no-mistakes signature in PR #42 body.
+
+signed same-head edited replay: exit 0
+Found no-mistakes signature in PR #42 body.
+PASS: unsigned body is rejected
+PASS: signed edit is accepted
+PASS: signed same-head replay is accepted
+
+RESULT: workflow acceptance passed

--- a/.no-mistakes/evidence/fm/nm-body-events-tasks-axi-r1/workflow_acceptance.rb
+++ b/.no-mistakes/evidence/fm/nm-body-events-tasks-axi-r1/workflow_acceptance.rb
@@ -1,0 +1,126 @@
+#!/usr/bin/env ruby
+
+require "open3"
+require "yaml"
+
+workflow_path = ".github/workflows/no-mistakes-required.yml"
+base = "0e2cf5904cc227bb66fed66bddac23da6ee449db"
+target = "460bdb68cbf7e0cb5692bb2f267676e53ed6c9f8"
+source = File.read(workflow_path)
+workflow = YAML.load_file(workflow_path)
+
+def assert(label, condition)
+  raise "FAIL: #{label}" unless condition
+
+  puts "PASS: #{label}"
+end
+
+puts "tasks-axi no-mistakes workflow acceptance"
+puts
+
+changed_files, changed_status = Open3.capture2(
+  "git", "diff", "--name-only", "#{base}..#{target}"
+)
+assert("committed scope is only the required workflow", changed_status.success? &&
+  changed_files.lines.map(&:strip) == [workflow_path])
+
+diff, diff_status = Open3.capture2(
+  "git", "diff", "#{base}..#{target}", "--", workflow_path
+)
+assert("the workflow change contains exactly two hunks",
+  diff_status.success? && diff.lines.count { |line| line.start_with?("@@") } == 2)
+
+expected_run_name = 'run-name: "PR #${{ github.event.pull_request.number }} body compliance - ${{ github.event.action }} - event ${{ github.run_number }} (run ${{ github.run_id }})"'
+expected_group = "group: no-mistakes-required-${{ github.event.pull_request.number }}-${{ (github.event.action == 'opened' || github.event.action == 'edited') && github.run_id || 'head-change' }}"
+
+assert("YAML syntax parses", workflow.is_a?(Hash))
+assert("canonical run-name is exact", source.include?(expected_run_name))
+assert("opened/edited use run_id while head changes coalesce", source.include?(expected_group))
+assert("cancel-in-progress remains true", source.match?(/^\s+cancel-in-progress: true$/))
+
+assert("pull_request trigger and event set are preserved",
+  source.include?("pull_request:\n    types: [opened, edited, synchronize, reopened]"))
+assert("main branch filter is preserved", source.include?("branches:\n      - main"))
+assert("permissions remain contents read-only",
+  source.include?("permissions:\n  contents: read\n") &&
+  !source.match?(/pull-requests:\s*write/) &&
+  !source.match?(/contents:\s*write/))
+assert("workflow does not use pull_request_target", !source.include?("pull_request_target"))
+assert("workflow does not reference secrets", !source.match?(/\bsecrets\./))
+assert("workflow does not check out or execute fork code",
+  !source.include?("actions/checkout") && !source.match?(/\bgithub\.event\.pull_request\.head\./))
+assert("stable check name is preserved", source.include?("name: PR must be raised via no-mistakes"))
+
+%w[github-actions[bot] dependabot[bot] release-please[bot]].each do |bot|
+  assert("#{bot} exemption is preserved", source.include?("'#{bot}'"))
+end
+
+marker = "Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)"
+assert("signature marker is preserved exactly", source.include?("marker='#{marker}'"))
+
+def identity(pr:, action:, run_number:, run_id:)
+  suffix = %w[opened edited].include?(action) ? run_id : "head-change"
+  group = "no-mistakes-required-#{pr}-#{suffix}"
+  name = "PR ##{pr} body compliance - #{action} - event #{run_number} (run #{run_id})"
+  [group, name]
+end
+
+events = [
+  ["unsigned opened", 42, "opened", 301, 9001],
+  ["signed edited", 42, "edited", 302, 9002],
+  ["signed same-head replay", 42, "edited", 303, 9003],
+  ["synchronize", 42, "synchronize", 304, 9004],
+  ["reopened", 42, "reopened", 305, 9005]
+]
+
+puts
+puts "Resolved run identities"
+events.each do |label, pr, action, run_number, run_id|
+  group, name = identity(pr: pr, action: action, run_number: run_number, run_id: run_id)
+  puts "#{label}:"
+  puts "  group: #{group}"
+  puts "  run-name: #{name}"
+end
+
+opened_group = identity(pr: 42, action: "opened", run_number: 301, run_id: 9001).first
+edit_group = identity(pr: 42, action: "edited", run_number: 302, run_id: 9002).first
+replay_group = identity(pr: 42, action: "edited", run_number: 303, run_id: 9003).first
+sync_group = identity(pr: 42, action: "synchronize", run_number: 304, run_id: 9004).first
+reopen_group = identity(pr: 42, action: "reopened", run_number: 305, run_id: 9005).first
+
+assert("opened, edited, and same-head replay cannot collapse",
+  [opened_group, edit_group, replay_group].uniq.length == 3)
+assert("synchronize and reopened retain head-change coalescing", sync_group == reopen_group)
+
+run_script = workflow.fetch("jobs").fetch("check").fetch("steps").first.fetch("run")
+
+def replay(run_script, label, body)
+  stdout, stderr, status = Open3.capture3(
+    {
+      "PR_BODY" => body,
+      "PR_AUTHOR" => "contributor",
+      "PR_NUMBER" => "42"
+    },
+    "bash", "-c", run_script
+  )
+  puts
+  puts "#{label}: exit #{status.exitstatus}"
+  print stdout
+  print stderr
+  status.exitstatus
+end
+
+unsigned = replay(run_script, "unsigned opened body", "A normal pull request body.")
+signed = replay(run_script, "signed edited body", "## Pipeline\n\n#{marker}")
+same_head = replay(
+  run_script,
+  "signed same-head edited replay",
+  "Updated context, unchanged head.\n\n## Pipeline\n\n#{marker}"
+)
+
+assert("unsigned body is rejected", unsigned == 1)
+assert("signed edit is accepted", signed == 0)
+assert("signed same-head replay is accepted", same_head == 0)
+
+puts
+puts "RESULT: workflow acceptance passed"


### PR DESCRIPTION
## Intent

Implement the captain-authorized repository-specific rollout of kunchenguid/no-mistakes#558 in tasks-axi. Apply only the exact two-hunk change to .github/workflows/no-mistakes-required.yml: add the canonical run-name and isolate every opened or edited PR-body event with github.run_id while keeping synchronize and reopened coalesced under head-change and retaining cancel-in-progress true. Preserve pull_request, contents read-only permissions, no secrets or fork-code execution, the stable check name, signature marker, bot exemptions, and all unrelated behavior. Validate YAML and Actions syntax, deterministic signed/unsigned/signed same-head replay, concurrency and run-name identities, preservation assertions, and the relevant repository build, lint, tests, and generated-skill check. Ship one PR titled 'fix: execute every PR body compliance event', stop when checks are green, and do not merge.

## What Changed

- Give each opened or edited pull request body event a unique concurrency group using `github.run_id`, while keeping synchronize and reopened events coalesced as head changes.
- Add a descriptive workflow run name without changing cancellation, permissions, signature checks, or bot exemptions.
- Add deterministic acceptance coverage for workflow identities, preserved safeguards, and signed and unsigned PR body handling.

## Risk Assessment

✅ Low: The workflow-only change exactly matches the canonical two-hunk rollout while preserving event triggers, read-only permissions, signature policy, bot exemptions, stable check name, and head-change coalescing.

## Testing

No baseline results were supplied. The focused workflow test confirmed the exact two-hunk scope, YAML and canonical Actions expressions, deterministic unsigned/signed/signed same-head replay, distinct opened/edited run identities, coalesced synchronize/reopened identity, and preservation of cancellation, triggers, permissions, check name, signature, bot exemptions, and fork safety. Repo-wide lint and full tests were not rerun under this targeted local-test boundary. No screenshot was applicable because this change has no rendered UI.

- Evidence: [Workflow acceptance transcript](https://github.com/kunchenguid/tasks-axi/blob/3ba0c0921f86a41135deecd3802f8c22f238ea8e/.no-mistakes/evidence/fm/nm-body-events-tasks-axi-r1/workflow-acceptance.txt)
- Evidence: [Focused acceptance harness](https://github.com/kunchenguid/tasks-axi/blob/3ba0c0921f86a41135deecd3802f8c22f238ea8e/.no-mistakes/evidence/fm/nm-body-events-tasks-axi-r1/workflow_acceptance.rb)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `git diff 0e2cf5904cc227bb66fed66bddac23da6ee449db..460bdb68cbf7e0cb5692bb2f267676e53ed6c9f8 -- .github/workflows/no-mistakes-required.yml`
- `ruby -e 'require "yaml"; YAML.load_file(ARGV[0])' .github/workflows/no-mistakes-required.yml`
- `ruby .no-mistakes/evidence/fm/nm-body-events-tasks-axi-r1/workflow_acceptance.rb`
- `GH_REPO=kunchenguid/no-mistakes gh-axi issue view 558 --full`
- <code>Compared the workflow&#39;s run-name and concurrency block with the merged canonical rollout at `bf51f006d0cf8fb675796a28382d85ff4f023ec7`.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
