### PR TITLE
fix: enforce backend capabilities and reject unsafe moves

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,8 @@ The CLI layer never knows which backend is active — it only talks to the `Stor
 - `src/cli.ts` — `runAxiCli` wiring: `DESCRIPTION`, `TOP_HELP`, the verb→handler map (with aliases create/view/edit/delete/close), the optional `task` noun prefix, and the global `--backend` / `--file` flags (stripped before handlers, parsed for `resolveContext`).
 - `src/context.ts` — `resolveTasksContext` builds the backend `Store` + `ResolvedConfig`; every command receives this `TasksContext`.
 - `src/store.ts` - the `Store` interface and `Capabilities`. Core contract: `create/get/update/remove/list/transition/addDep/removeDep/updatePublicFollowup`. `prune`/`render` are optional and capability-gated.
+  Declared capability booleans are enforced at the command layer with `requireCapability` (`src/errors.ts`) - gate any new capability-dependent command there, never inside a backend.
+  `mv` refuses a non-markdown source outright (`src/commands/state.ts`): a cross-backend move would copy-then-delete and lose backend-specific state.
 - `src/model.ts` — the `Task` data model (report §5).
 - `src/derive.ts` - worker `blocked` / `ready` / active `held` and public delivery readiness are derived in the CLI from `list` + the dep graph + hold date gates, never Store methods, so every backend gets them for free.
 - `src/backends/markdown*.ts` — the only P1 backend.

--- a/skills/tasks-axi/SKILL.md
+++ b/skills/tasks-axi/SKILL.md
@@ -56,5 +56,6 @@ Run `npx -y tasks-axi --help` for global flags, or `npx -y tasks-axi <command> -
 - Existing prose markers such as `HELD`, `PARKED`, `DEFERRED`, `CAPTAIN-DECISION`, and `do not dispatch` stay prose until intentionally migrated.
   Preserve the original prose as the hold reason, then choose `captain`, `parked`, `future`, `load`, or `external` only when the text supports that bucket.
 - Note writes are inspect-then-update: run `show <id> --full`, then replace the curated current body with `update <id> --body "<text>"` or `--body-file <path>`.
-  Add `--archive-body` to preserve the superseded body in `note-archive.md`; `--title "<text>"` replaces the title; `render` normalizes the file; `mv <id> [<id>...] --to <path>` moves one or more tasks to another backlog in one atomic transaction - pass a whole connected set (a blocker and its dependents) to move it together and preserve its `blocked-by` links and reason strings; moves that would strand an endpoint are refused.
+  Add `--archive-body` to preserve the superseded body in `note-archive.md`; `--title "<text>"` replaces the title; `render` normalizes the file.
+- Run `mv --help` before moving tasks between backlog files; it owns the source-backend and dependency safety constraints.
 - Free-form (no-id) backlog lines are preserved verbatim and are never modified.

--- a/src/commands/crud.ts
+++ b/src/commands/crud.ts
@@ -13,7 +13,7 @@ import { deriveLinks, extractTags } from "../backends/markdown-grammar.js";
 import { renderMutation, stateLabel, taskToJson } from "../confirm.js";
 import { requireCtx, type TasksContext } from "../context.js";
 import { blockedIds, heldTasks } from "../derive.js";
-import { AxiError, notFound } from "../errors.js";
+import { AxiError, notFound, requireCapability } from "../errors.js";
 import { parseFields } from "../fields.js";
 import { formatCountLine } from "../format.js";
 import {
@@ -287,6 +287,7 @@ export async function addCommand(
   if (deps.some((dep) => dep.id === id)) {
     throw new AxiError("A task cannot block itself", "VALIDATION_ERROR");
   }
+  if (deps.length > 0) requireCapability(store, "deps", "dependencies");
   await requireExistingBlockers(store, deps);
   const links = parseLinks(pr, report);
 

--- a/src/commands/public-followup.ts
+++ b/src/commands/public-followup.ts
@@ -14,7 +14,7 @@ import {
   publicFollowupsByDeliveryState,
   readyPublicFollowups,
 } from "../derive.js";
-import { AxiError, notFound } from "../errors.js";
+import { AxiError, notFound, requireCapability } from "../errors.js";
 import { formatCountLine } from "../format.js";
 import type { Task } from "../model.js";
 import {
@@ -104,6 +104,13 @@ export async function publicFollowupCommand(
   context?: TasksContext,
 ): Promise<string> {
   const [command, ...args] = rawArgs;
+  if (command !== undefined && command in SUBCOMMAND_HELP) {
+    requireCapability(
+      requireCtx(context).store,
+      "publicFollowups",
+      "public-followup",
+    );
+  }
   switch (command) {
     case "add":
       return publicFollowupAdd(args, context);

--- a/src/commands/public-followup.ts
+++ b/src/commands/public-followup.ts
@@ -93,10 +93,14 @@ const SUBCOMMAND_HELP: Record<string, string> = {
     "usage: tasks-axi public-followup waive <id> --reason <text> --approved-by captain [--json]",
 };
 
+function hasSubcommand(command: string | undefined): command is string {
+  return command !== undefined && Object.hasOwn(SUBCOMMAND_HELP, command);
+}
+
 export function publicFollowupSubcommandHelp(
   command: string | undefined,
 ): string | undefined {
-  return command === undefined ? undefined : SUBCOMMAND_HELP[command];
+  return hasSubcommand(command) ? SUBCOMMAND_HELP[command] : undefined;
 }
 
 export async function publicFollowupCommand(
@@ -104,7 +108,7 @@ export async function publicFollowupCommand(
   context?: TasksContext,
 ): Promise<string> {
   const [command, ...args] = rawArgs;
-  if (command !== undefined && command in SUBCOMMAND_HELP) {
+  if (hasSubcommand(command)) {
     requireCapability(
       requireCtx(context).store,
       "publicFollowups",

--- a/src/commands/state.ts
+++ b/src/commands/state.ts
@@ -19,23 +19,18 @@ import {
   readyPublicFollowups,
   readyTasks,
 } from "../derive.js";
-import { AxiError, notFound } from "../errors.js";
+import { AxiError, notFound, requireCapability } from "../errors.js";
 import { formatCountLine } from "../format.js";
 import { validateDependencyId } from "../id.js";
 import type {
   Dep,
   Hold,
   HoldKind,
-  Task,
-  TaskInput,
   TaskLink,
   TaskPatch,
 } from "../model.js";
 import { HOLD_KINDS } from "../model.js";
-import {
-  PUBLIC_FOLLOWUP_KIND,
-  clonePublicFollowup,
-} from "../public-followup.js";
+import { PUBLIC_FOLLOWUP_KIND } from "../public-followup.js";
 import type { Store } from "../store.js";
 import { getSuggestions } from "../suggestions.js";
 import { renderHelp, renderOutput } from "../toon.js";
@@ -391,6 +386,7 @@ export async function blockCommand(
   context?: TasksContext,
 ): Promise<string> {
   const { store } = requireCtx(context);
+  requireCapability(store, "deps", "dependencies");
   const args = [...rawArgs];
   const json = takeBoolFlag(args, "--json");
   const by = requireBy(args);
@@ -434,6 +430,7 @@ export async function unblockCommand(
   context?: TasksContext,
 ): Promise<string> {
   const { store } = requireCtx(context);
+  requireCapability(store, "deps", "dependencies");
   const args = [...rawArgs];
   const json = takeBoolFlag(args, "--json");
   const by = requireBy(args);
@@ -653,28 +650,6 @@ function resolveBacklogTarget(to: string): string {
   return base;
 }
 
-function taskToInput(task: Task): TaskInput {
-  const input: TaskInput = {
-    id: task.id,
-    title: task.title,
-    state: task.state,
-    deps: task.deps.map((dep) => ({ ...dep })),
-    links: task.links.map((link) => ({ ...link })),
-  };
-  if (task.kind) input.kind = task.kind;
-  if (task.repo) input.repo = task.repo;
-  if (task.body) input.body = task.body;
-  if (task.hold) input.hold = { ...task.hold };
-  if (task.priority !== undefined) input.priority = task.priority;
-  input.created = task.created ?? null;
-  if (task.closed) input.closed = task.closed;
-  if (task.public_followup) {
-    input.public_followup = clonePublicFollowup(task.public_followup);
-  }
-  if (task.meta) input.meta = { ...task.meta };
-  return input;
-}
-
 export async function mvCommand(
   rawArgs: string[],
   context?: TasksContext,
@@ -706,11 +681,22 @@ export async function mvCommand(
     );
   }
 
-  const tasks: Task[] = [];
+  // A cross-backend move would recreate the task in a markdown file and
+  // delete the source record — a data-loss path, so refuse it outright.
+  if (!(store instanceof MarkdownStore)) {
+    throw new AxiError(
+      `mv moves tasks between markdown backlog files; the ${store.capabilities().backend} backend cannot be a move source`,
+      "UNSUPPORTED",
+      [
+        "Recreate the task in the destination backlog with `tasks-axi add`, then `tasks-axi rm` it here once confirmed",
+      ],
+    );
+  }
+
   for (const id of ids) {
-    const task = await store.get(id);
-    if (!task) throw notFound(id, { globals: context?.suggestionGlobals });
-    tasks.push(task);
+    if (!(await store.get(id))) {
+      throw notFound(id, { globals: context?.suggestionGlobals });
+    }
   }
 
   const target = new MarkdownStore({ path: targetPath });
@@ -723,17 +709,7 @@ export async function mvCommand(
     }
   }
 
-  if (store instanceof MarkdownStore) {
-    await store.moveManyTo(ids, target);
-  } else if (ids.length === 1) {
-    await target.create(taskToInput(tasks[0]));
-    await store.remove(ids[0]);
-  } else {
-    throw new AxiError(
-      "Moving multiple tasks at once requires the markdown backend",
-      "UNSUPPORTED",
-    );
-  }
+  await store.moveManyTo(ids, target);
 
   const single = ids.length === 1;
   return renderMutation({

--- a/src/commands/state.ts
+++ b/src/commands/state.ts
@@ -22,13 +22,7 @@ import {
 import { AxiError, notFound, requireCapability } from "../errors.js";
 import { formatCountLine } from "../format.js";
 import { validateDependencyId } from "../id.js";
-import type {
-  Dep,
-  Hold,
-  HoldKind,
-  TaskLink,
-  TaskPatch,
-} from "../model.js";
+import type { Dep, Hold, HoldKind, TaskLink, TaskPatch } from "../model.js";
 import { HOLD_KINDS } from "../model.js";
 import { PUBLIC_FOLLOWUP_KIND } from "../public-followup.js";
 import type { Store } from "../store.js";
@@ -96,6 +90,7 @@ Held work is excluded by default; --include-held shows it in a separate held gro
 
 export const MV_HELP = `usage: tasks-axi mv <id> [<id>...] --to <path-or-dir>
 Move one or more tasks to another backlog file in a single atomic transaction.
+The active source backend must be markdown; other backends are refused without mutation.
 Pass a whole connected set (a blocker and its dependents) to move it together;
 their blocked-by links and reason strings are preserved byte-exact.
 Duplicate ids are ignored after their first occurrence.
@@ -682,7 +677,7 @@ export async function mvCommand(
   }
 
   // A cross-backend move would recreate the task in a markdown file and
-  // delete the source record — a data-loss path, so refuse it outright.
+  // delete the source record. Refuse that data-loss path outright.
   if (!(store instanceof MarkdownStore)) {
     throw new AxiError(
       `mv moves tasks between markdown backlog files; the ${store.capabilities().backend} backend cannot be a move source`,

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,4 +1,5 @@
 import { AxiError, exitCodeForError } from "axi-sdk-js";
+import type { Capabilities, Store } from "./store.js";
 import {
   type SuggestionGlobals,
   withSuggestionGlobals,
@@ -44,4 +45,18 @@ export function unsupported(capability: string, backend: string): AxiError {
     `The ${backend} backend does not support ${capability}`,
     "UNSUPPORTED",
   );
+}
+
+/**
+ * Enforce a declared `Capabilities` boolean before a command touches the
+ * store: a backend that declares a capability false gets a structured
+ * refusal naming the user-facing feature, never a raw backend error.
+ */
+export function requireCapability(
+  store: Store,
+  capability: Exclude<keyof Capabilities, "backend">,
+  feature: string,
+): void {
+  const caps = store.capabilities();
+  if (!caps[capability]) throw unsupported(feature, caps.backend);
 }

--- a/src/skill.ts
+++ b/src/skill.ts
@@ -95,7 +95,8 @@ Run \`npx -y tasks-axi --help\` for global flags, or \`npx -y tasks-axi <command
 - Existing prose markers such as \`HELD\`, \`PARKED\`, \`DEFERRED\`, \`CAPTAIN-DECISION\`, and \`do not dispatch\` stay prose until intentionally migrated.
   Preserve the original prose as the hold reason, then choose \`captain\`, \`parked\`, \`future\`, \`load\`, or \`external\` only when the text supports that bucket.
 - Note writes are inspect-then-update: run \`show <id> --full\`, then replace the curated current body with \`update <id> --body "<text>"\` or \`--body-file <path>\`.
-  Add \`--archive-body\` to preserve the superseded body in \`note-archive.md\`; \`--title "<text>"\` replaces the title; \`render\` normalizes the file; \`mv <id> [<id>...] --to <path>\` moves one or more tasks to another backlog in one atomic transaction - pass a whole connected set (a blocker and its dependents) to move it together and preserve its \`blocked-by\` links and reason strings; moves that would strand an endpoint are refused.
+  Add \`--archive-body\` to preserve the superseded body in \`note-archive.md\`; \`--title "<text>"\` replaces the title; \`render\` normalizes the file.
+- Run \`mv --help\` before moving tasks between backlog files; it owns the source-backend and dependency safety constraints.
 - Free-form (no-id) backlog lines are preserved verbatim and are never modified.
 `;
 }

--- a/src/store.ts
+++ b/src/store.ts
@@ -11,13 +11,18 @@ import type {
 } from "./model.js";
 
 /**
- * Backend capability descriptor (report §8). Optional capabilities degrade
- * gracefully: the CLI computes a missing capability from the core verbs, or
- * returns a structured error naming the capability — never a raw backend error.
+ * Backend capability descriptor (report §8).
+ *
+ * Command handlers must enforce each capability they depend on with
+ * `requireCapability` before calling the store. A false declaration produces a
+ * structured UNSUPPORTED error naming the feature and backend.
+ * `prune` and `render` retain their method-presence checks because their Store
+ * methods are optional.
  */
 export interface Capabilities {
   /** Backend identifier, e.g. "markdown". */
   backend: string;
+  /** Supports dependency-writing commands. */
   deps: boolean;
   prune: boolean;
   comments: boolean;
@@ -27,7 +32,7 @@ export interface Capabilities {
   customStates: boolean;
   /** Does the server assign its own ids (remote trackers)? */
   serverMintsIds: boolean;
-  /** Supports the durable, receipt-gated public-followup state machine. */
+  /** Supports every command in the durable public-followup namespace. */
   publicFollowups: boolean;
 }
 

--- a/test/commands/crud.test.ts
+++ b/test/commands/crud.test.ts
@@ -8,7 +8,7 @@ import {
   showCommand,
   updateCommand,
 } from "../../src/commands/crud.js";
-import { makeBacklog } from "../helpers.js";
+import { makeBacklog, makeFakeBackendBacklog } from "../helpers.js";
 
 describe("crud commands", () => {
   describe("add", () => {
@@ -23,6 +23,24 @@ describe("crud commands", () => {
         expect(out).toContain("state: queued");
         expect(out).toContain("Run `tasks-axi start new-q1`");
         expect(b.read()).toContain("- [ ] new-q1 - a fresh task");
+      } finally {
+        b.cleanup();
+      }
+    });
+
+    it("refuses --blocked-by when the backend declares deps unsupported", async () => {
+      const b = makeFakeBackendBacklog({ deps: false });
+      try {
+        await expect(
+          addCommand(
+            ["new-q1", "a fresh task", "--blocked-by", "cert-cleanup"],
+            b.ctx,
+          ),
+        ).rejects.toMatchObject({
+          code: "UNSUPPORTED",
+          message: "The fake backend does not support dependencies",
+        });
+        expect(await b.ctx.store.get("new-q1")).toBeNull();
       } finally {
         b.cleanup();
       }

--- a/test/commands/public-followup.test.ts
+++ b/test/commands/public-followup.test.ts
@@ -204,16 +204,16 @@ describe("public-followup commands", () => {
   it("refuses every subcommand when the backend declares publicFollowups unsupported", async () => {
     const b = makeFakeBackendBacklog({ publicFollowups: false }, EMPTY);
     try {
-      await expect(publicFollowupCommand(["ready"], b.ctx)).rejects.toMatchObject(
-        {
-          code: "UNSUPPORTED",
-          message: "The fake backend does not support public-followup",
-        },
-      );
+      await expect(
+        publicFollowupCommand(["ready"], b.ctx),
+      ).rejects.toMatchObject({
+        code: "UNSUPPORTED",
+        message: "The fake backend does not support public-followup",
+      });
       // An unknown subcommand still reads as a usage error, not a capability one.
-      await expect(publicFollowupCommand(["bogus"], b.ctx)).rejects.toMatchObject(
-        { code: "VALIDATION_ERROR" },
-      );
+      await expect(
+        publicFollowupCommand(["bogus"], b.ctx),
+      ).rejects.toMatchObject({ code: "VALIDATION_ERROR" });
       await expect(
         publicFollowupCommand(["toString"], b.ctx),
       ).rejects.toMatchObject({ code: "VALIDATION_ERROR" });

--- a/test/commands/public-followup.test.ts
+++ b/test/commands/public-followup.test.ts
@@ -214,6 +214,9 @@ describe("public-followup commands", () => {
       await expect(publicFollowupCommand(["bogus"], b.ctx)).rejects.toMatchObject(
         { code: "VALIDATION_ERROR" },
       );
+      await expect(
+        publicFollowupCommand(["toString"], b.ctx),
+      ).rejects.toMatchObject({ code: "VALIDATION_ERROR" });
     } finally {
       b.cleanup();
     }

--- a/test/commands/public-followup.test.ts
+++ b/test/commands/public-followup.test.ts
@@ -19,7 +19,11 @@ import {
   clonePublicFollowup,
   encodePublicFollowup,
 } from "../../src/public-followup.js";
-import { makeBacklog, type TempBacklog } from "../helpers.js";
+import {
+  makeBacklog,
+  makeFakeBackendBacklog,
+  type TempBacklog,
+} from "../helpers.js";
 
 const EMPTY =
   "# Backlog\n\n## In flight\n\n## Queued\n- [ ] ordinary-q1 - ordinary work\n\n## Done\n";
@@ -197,6 +201,24 @@ async function begin(b: TempBacklog): Promise<Record<string, any>> {
 }
 
 describe("public-followup commands", () => {
+  it("refuses every subcommand when the backend declares publicFollowups unsupported", async () => {
+    const b = makeFakeBackendBacklog({ publicFollowups: false }, EMPTY);
+    try {
+      await expect(publicFollowupCommand(["ready"], b.ctx)).rejects.toMatchObject(
+        {
+          code: "UNSUPPORTED",
+          message: "The fake backend does not support public-followup",
+        },
+      );
+      // An unknown subcommand still reads as a usage error, not a capability one.
+      await expect(publicFollowupCommand(["bogus"], b.ctx)).rejects.toMatchObject(
+        { code: "VALIDATION_ERROR" },
+      );
+    } finally {
+      b.cleanup();
+    }
+  });
+
   it("round-trips canonical typed metadata through render, task update, and move", async () => {
     const b = makeBacklog(EMPTY);
     const target = makeBacklog(

--- a/test/commands/state.test.ts
+++ b/test/commands/state.test.ts
@@ -1,4 +1,10 @@
-import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
@@ -13,7 +19,7 @@ import {
   unholdCommand,
 } from "../../src/commands/state.js";
 import { listCommand } from "../../src/commands/crud.js";
-import { makeBacklog } from "../helpers.js";
+import { makeBacklog, makeFakeBackendBacklog } from "../helpers.js";
 
 describe("state commands", () => {
   it("rejects malformed primary ids before store lookup", async () => {
@@ -536,6 +542,25 @@ describe("state commands", () => {
         b.cleanup();
       }
     });
+
+    it("refuses when the backend declares deps unsupported", async () => {
+      const b = makeFakeBackendBacklog({ deps: false });
+      try {
+        await expect(
+          blockCommand(["cert-cleanup", "--by", "owns-widget-h7"], b.ctx),
+        ).rejects.toMatchObject({
+          code: "UNSUPPORTED",
+          message: "The fake backend does not support dependencies",
+        });
+        expect(b.read()).not.toContain("blocked-by: owns-widget-h7");
+        await expect(
+          unblockCommand(["lease-adopt", "--by", "lease-core-t4"], b.ctx),
+        ).rejects.toMatchObject({ code: "UNSUPPORTED" });
+        expect(b.read()).toContain("blocked-by: lease-core-t4");
+      } finally {
+        b.cleanup();
+      }
+    });
   });
 
   describe("ready", () => {
@@ -895,6 +920,24 @@ describe("state commands", () => {
       } finally {
         b.cleanup();
         target.cleanup();
+      }
+    });
+
+    it("refuses a non-markdown source instead of copy-deleting the task", async () => {
+      const b = makeFakeBackendBacklog();
+      const targetPath = join(b.dir, "target.md");
+      try {
+        await expect(
+          mvCommand(["cert-cleanup", "--to", targetPath], b.ctx),
+        ).rejects.toMatchObject({
+          code: "UNSUPPORTED",
+          message:
+            "mv moves tasks between markdown backlog files; the fake backend cannot be a move source",
+        });
+        expect(await b.ctx.store.get("cert-cleanup")).not.toBeNull();
+        expect(existsSync(targetPath)).toBe(false);
+      } finally {
+        b.cleanup();
       }
     });
 

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { MarkdownStore } from "../src/backends/markdown.js";
 import type { TasksContext } from "../src/context.js";
+import type { Capabilities, Store } from "../src/store.js";
 
 export const FIXTURE = readFileSync(
   new URL("./fixtures/backlog.md", import.meta.url),
@@ -79,4 +80,39 @@ export function makeBacklog(
     },
     cleanup: () => rmSync(dir, { recursive: true, force: true }),
   };
+}
+
+export interface FakeBackendBacklog extends Omit<TempBacklog, "store"> {
+  store: Store;
+}
+
+/**
+ * A non-markdown backend for seam tests: a real MarkdownStore wrapped behind
+ * the plain Store interface (so it fails `instanceof MarkdownStore`),
+ * reporting backend "fake" with the given capability overrides.
+ */
+export function makeFakeBackendBacklog(
+  overrides: Partial<Capabilities> = {},
+  content = FIXTURE,
+): FakeBackendBacklog {
+  const b = makeBacklog(content);
+  const inner = b.store;
+  const store: Store = {
+    capabilities: () => ({
+      ...inner.capabilities(),
+      backend: "fake",
+      ...overrides,
+    }),
+    create: (input) => inner.create(input),
+    get: (id) => inner.get(id),
+    update: (id, patch) => inner.update(id, patch),
+    remove: (id) => inner.remove(id),
+    list: (query) => inner.list(query),
+    transition: (id, to, opts) => inner.transition(id, to, opts),
+    addDep: (id, dep) => inner.addDep(id, dep),
+    removeDep: (id, dep) => inner.removeDep(id, dep),
+    updatePublicFollowup: (id, mutation) =>
+      inner.updatePublicFollowup(id, mutation),
+  };
+  return { ...b, store, ctx: { store, config: b.ctx.config } };
 }


### PR DESCRIPTION
## Intent

Harden the backend seam ahead of additional Store backends (sqlite, remote trackers) by fixing two live defects, with no behavior change for the markdown backend's happy paths. (1) The Capabilities booleans declared by Store.capabilities() were never consumed anywhere, so a backend declaring a capability false (e.g. publicFollowups) blocked nothing. Add a generic enforcement gate at the command layer - a requireCapability helper in src/errors.ts driven by the declared booleans, following the existing unsupported()/UNSUPPORTED error convention - and apply it to the public-followup command group (publicFollowups) and the dependency-writing commands block/unblock/add --blocked-by (deps). Deliberate decisions: the gate lives in the command layer rather than inside backends; unknown public-followup subcommands still return their usage error before the capability check; prune/render keep their existing method-presence gate. (2) mv hardcoded a markdown target and fell back to create-then-remove for a non-markdown source, which would recreate the task as a markdown file and delete the source record - a data-loss path for any future non-markdown backend. mv now refuses a non-markdown source outright with an actionable UNSUPPORTED error, and the dead create-then-remove fallback (taskToInput) is deleted; markdown-to-markdown mv byte output is unchanged. Tests: a makeFakeBackendBacklog helper (real MarkdownStore wrapped behind the plain Store interface with capability overrides) plus 4 colocated tests verified to fail before and pass after the fix; full suite stays green. Also documented the gate and mv refusal in AGENTS.md for future backend authors.

## What Changed

- Enforce declared backend capabilities for dependency mutations and all public follow-up commands, returning structured `UNSUPPORTED` errors when unavailable.
- Reject `mv` from non-markdown backends to prevent lossy copy-and-delete behavior while preserving markdown-to-markdown moves.
- Add fake-backend regression coverage and document the capability gate and move constraints for future backend implementations.

## Risk Assessment

✅ Low: The change is well-bounded, satisfies the stated capability-gating and move-safety requirements, and the inherited-property dispatch defect from the prior round is correctly fixed with focused regression coverage.

## Testing

Inspected the base-to-target change, ran the four focused guard tests plus five supported-markdown regression tests, then captured a direct CLI-style transcript proving structured refusals, error-order precedence, non-mutation guarantees, safe mv refusal, and successful markdown mv; all checks passed after correcting the evidence harness to run as ESM.

<details>
<summary>Evidence: CLI capability gates and mv safety transcript</summary>

```text
tasks-axi capability gates and mv safety transcript
==================================================

$ tasks-axi public-followup ready
error: The fake backend does not support public-followup
code: UNSUPPORTED
exit: 1
persisted_state: unchanged

$ tasks-axi public-followup bogus
error: "Unknown public-followup command: bogus"
code: VALIDATION_ERROR
help[1]: "usage: tasks-axi public-followup <command> [args] [flags]"
exit: 2
ordering: unknown subcommand remains a VALIDATION_ERROR

$ tasks-axi add new-q1 "a fresh task" --blocked-by cert-cleanup
error: The fake backend does not support dependencies
code: UNSUPPORTED
exit: 1
persisted_state: new-q1 exists=false

$ tasks-axi block cert-cleanup --by owns-widget-h7
error: The fake backend does not support dependencies
code: UNSUPPORTED
exit: 1
persisted_state: ledger byte-identical=true

$ tasks-axi unblock lease-adopt --by lease-core-t4
error: The fake backend does not support dependencies
code: UNSUPPORTED
exit: 1
persisted_state: original edge retained=true

$ tasks-axi mv cert-cleanup --to /tmp/tasks-axi-H9FtN9/target.md
error: mv moves tasks between markdown backlog files; the fake backend cannot be a move source
code: UNSUPPORTED
help[1]: "Recreate the task in the destination backlog with `tasks-axi add`, then `tasks-axi rm` it here once confirmed"
exit: 1
persisted_state: source task retained=true
destination_created: false

$ tasks-axi mv cert-cleanup --to /tmp/tasks-axi-jJWQzp/backlog.md
ok: mv cert-cleanup -> /tmp/tasks-axi-jJWQzp/backlog.md
help[1]:
  - Run `tasks-axi list` to see remaining tasks
source_contains_task: false
destination_contains_task: true
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- 🚨 `src/commands/public-followup.ts:107` - The required criterion says unknown public-followup subcommands must return their usage error before capability checking, but `command in SUBCOMMAND_HELP` also accepts inherited keys such as `toString`, `constructor`, and `__proto__`. On an unsupported backend those unknown commands incorrectly return `UNSUPPORTED`. Use an own-property check such as `Object.hasOwn(SUBCOMMAND_HELP, command)`.

🔧 Fix: Harden public-followup subcommand ownership checks
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `pnpm exec vitest run test/commands/crud.test.ts test/commands/public-followup.test.ts test/commands/state.test.ts -t "refuses --blocked-by when the backend declares deps unsupported|refuses every subcommand when the backend declares publicFollowups unsupported|refuses when the backend declares deps unsupported|refuses a non-markdown source instead of copy-deleting the task"`
- `pnpm exec vitest run test/commands/crud.test.ts test/commands/public-followup.test.ts test/commands/state.test.ts -t "records blocked-by when the target exists|adds and clears a blocked-by edge idempotently|moves a task to another backlog file|round-trips canonical typed metadata through render, task update, and move"`
- `pnpm exec vitest run test/commands/state.test.ts -t "moves a connected blocker/dependent pair atomically, reason byte-exact"`
- <code>`pnpm exec tsx /tmp/no-mistakes-evidence/01KYP8PEBJEJR3M7388AMT4MW8/capture-evidence.mts` to exercise command handlers through fake and markdown stores, render actual AXI errors, and verify persisted state after each command</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
