### PR TITLE
chore(ci): skip pull_request runs for release-please output-only PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,13 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    # release-please opens its release PR with GITHUB_TOKEN, which creates a
+    # pull_request run that can only sit in action_required. Its output set is
+    # exactly these files, so excluding them means no run is ever created.
+    paths-ignore:
+      - .release-please-manifest.json
+      - CHANGELOG.md
+      - package.json
 
 jobs:
   build-and-test:

--- a/.github/workflows/guard-generated-files.yml
+++ b/.github/workflows/guard-generated-files.yml
@@ -5,6 +5,13 @@ on:
     types: [opened, synchronize, reopened]
     branches:
       - main
+    # Never create a run for a release-please PR. The job-level author exemption
+    # below cannot do this: it is evaluated inside a run, and a GITHUB_TOKEN PR's
+    # run is created in action_required and never starts.
+    paths-ignore:
+      - .release-please-manifest.json
+      - CHANGELOG.md
+      - package.json
 
 permissions:
   contents: read

--- a/.github/workflows/no-mistakes-required.yml
+++ b/.github/workflows/no-mistakes-required.yml
@@ -6,6 +6,13 @@ on:
     types: [opened, edited, synchronize, reopened]
     branches:
       - main
+    # Never create a run for a release-please PR. The job-level author exemption
+    # below cannot do this: it is evaluated inside a run, and a GITHUB_TOKEN PR's
+    # run is created in action_required and never starts.
+    paths-ignore:
+      - .release-please-manifest.json
+      - CHANGELOG.md
+      - package.json
 
 permissions:
   contents: read

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,6 +75,7 @@ The CLI layer never knows which backend is active — it only talks to the `Stor
 ### Release & packaging (mirrors the `*-axi` siblings)
 
 - **Published to npm as a public package** via `release-please` → `npm publish --access public --provenance` on a release commit (`.github/workflows/release-please.yml`); the captain can also `npm publish` manually. Conventional commits drive the version bump; `release-please-config.json` + `.release-please-manifest.json` own versioning and `CHANGELOG.md`.
+- Every `pull_request` workflow (`ci.yml`, `guard-generated-files.yml`, `no-mistakes-required.yml`) uses `paths-ignore` for the release-please output set (`.release-please-manifest.json`, `CHANGELOG.md`, `package.json`) so release PRs create zero runs. Job-level bot `if`s stay as defense in depth. `test/release-ci-exclusions.test.ts` derives that set from `release-please-config.json` and fails if a workflow drifts; update the ignore lists when adding `extra-files` or changing `release-type`.
 - **The tarball ships runtime JS only.** `package.json` `files` is `dist/**/*.js` (+ `skills/tasks-axi`, `LICENSE`, `README.md`), so the `.d.ts`/`.js.map` that `tsc` emits for local debugging are kept out of the package.
   `prepack` runs `npm run build`, so `npm pack`/`npm publish` always rebuild `dist` first.
   In a fresh clone, run `pnpm install --frozen-lockfile` before manual pack or publish.

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "tsx": "^4.0.0",
     "typescript": "^5.7.0",
     "typescript-eslint": "^8.58.0",
-    "vitest": "^3.0.0"
+    "vitest": "^3.0.0",
+    "yaml": "^2.9.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,7 +41,10 @@ importers:
         version: 8.61.1(eslint@10.5.0)(typescript@5.9.3)
       vitest:
         specifier: ^3.0.0
-        version: 3.2.6(@types/node@22.19.21)(tsx@4.22.4)
+        version: 3.2.6(@types/node@22.19.21)(tsx@4.22.4)(yaml@2.9.0)
+      yaml:
+        specifier: ^2.9.0
+        version: 2.9.0
 
 packages:
 
@@ -1133,6 +1136,11 @@ packages:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
 
+  yaml@2.9.0:
+    resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
@@ -1540,13 +1548,13 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.6(vite@7.3.5(@types/node@22.19.21)(tsx@4.22.4))':
+  '@vitest/mocker@3.2.6(vite@7.3.5(@types/node@22.19.21)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 3.2.6
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.5(@types/node@22.19.21)(tsx@4.22.4)
+      vite: 7.3.5(@types/node@22.19.21)(tsx@4.22.4)(yaml@2.9.0)
 
   '@vitest/pretty-format@3.2.6':
     dependencies:
@@ -1983,13 +1991,13 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  vite-node@3.2.4(@types/node@22.19.21)(tsx@4.22.4):
+  vite-node@3.2.4(@types/node@22.19.21)(tsx@4.22.4)(yaml@2.9.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.3.5(@types/node@22.19.21)(tsx@4.22.4)
+      vite: 7.3.5(@types/node@22.19.21)(tsx@4.22.4)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -2004,7 +2012,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite@7.3.5(@types/node@22.19.21)(tsx@4.22.4):
+  vite@7.3.5(@types/node@22.19.21)(tsx@4.22.4)(yaml@2.9.0):
     dependencies:
       esbuild: 0.27.7
       fdir: 6.5.0(picomatch@4.0.4)
@@ -2016,12 +2024,13 @@ snapshots:
       '@types/node': 22.19.21
       fsevents: 2.3.3
       tsx: 4.22.4
+      yaml: 2.9.0
 
-  vitest@3.2.6(@types/node@22.19.21)(tsx@4.22.4):
+  vitest@3.2.6(@types/node@22.19.21)(tsx@4.22.4)(yaml@2.9.0):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.6
-      '@vitest/mocker': 3.2.6(vite@7.3.5(@types/node@22.19.21)(tsx@4.22.4))
+      '@vitest/mocker': 3.2.6(vite@7.3.5(@types/node@22.19.21)(tsx@4.22.4)(yaml@2.9.0))
       '@vitest/pretty-format': 3.2.6
       '@vitest/runner': 3.2.6
       '@vitest/snapshot': 3.2.6
@@ -2039,8 +2048,8 @@ snapshots:
       tinyglobby: 0.2.17
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.3.5(@types/node@22.19.21)(tsx@4.22.4)
-      vite-node: 3.2.4(@types/node@22.19.21)(tsx@4.22.4)
+      vite: 7.3.5(@types/node@22.19.21)(tsx@4.22.4)(yaml@2.9.0)
+      vite-node: 3.2.4(@types/node@22.19.21)(tsx@4.22.4)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.19.21
@@ -2068,5 +2077,7 @@ snapshots:
       stackback: 0.0.2
 
   word-wrap@1.2.5: {}
+
+  yaml@2.9.0: {}
 
   yocto-queue@0.1.0: {}

--- a/test/release-ci-exclusions.test.ts
+++ b/test/release-ci-exclusions.test.ts
@@ -1,0 +1,231 @@
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { parse } from "yaml";
+
+const root = fileURLToPath(new URL("..", import.meta.url));
+const workflowsDir = join(root, ".github", "workflows");
+
+/**
+ * Derive the exact release-please output set from config + workflow inputs.
+ * Keep this aligned with the fleet audit rule in firstmate's release-please CI
+ * report: node -> package.json (+ package-lock.json if present), changelog,
+ * extra-files, and the manifest path.
+ */
+function expectedReleaseOutputs(): string[] {
+  const config = JSON.parse(
+    readFileSync(join(root, "release-please-config.json"), "utf8"),
+  ) as {
+    "release-type"?: string;
+    "changelog-path"?: string;
+    "version-file"?: string;
+    "extra-files"?: Array<string | { path?: string }>;
+    packages?: Record<
+      string,
+      {
+        "release-type"?: string;
+        "changelog-path"?: string;
+        "version-file"?: string;
+        "extra-files"?: Array<string | { path?: string }>;
+      }
+    >;
+  };
+  const pkg = config.packages?.["."] ?? {};
+  const releaseType = pkg["release-type"] ?? config["release-type"] ?? "node";
+  const changelog =
+    pkg["changelog-path"] ?? config["changelog-path"] ?? "CHANGELOG.md";
+
+  const expected: string[] = [changelog];
+  switch (releaseType) {
+    case "simple":
+      expected.push(
+        pkg["version-file"] ?? config["version-file"] ?? "version.txt",
+      );
+      break;
+    case "node":
+      expected.push("package.json");
+      if (existsSync(join(root, "package-lock.json"))) {
+        expected.push("package-lock.json");
+      }
+      break;
+    case "go":
+      break;
+    default:
+      throw new Error(
+        `unsupported release-please release-type for ignore derivation: ${releaseType}`,
+      );
+  }
+
+  const extra = pkg["extra-files"] ?? config["extra-files"] ?? [];
+  for (const entry of extra) {
+    const path = typeof entry === "string" ? entry : entry?.path;
+    if (path) expected.push(path);
+  }
+
+  let manifest = ".release-please-manifest.json";
+  const releaseWorkflow = readFileSync(
+    join(workflowsDir, "release-please.yml"),
+    "utf8",
+  );
+  const manifestMatch = releaseWorkflow.match(/manifest-file:\s*(\S+)/);
+  if (manifestMatch) manifest = manifestMatch[1];
+  expected.push(manifest);
+
+  return [...new Set(expected)];
+}
+
+function loadWorkflowOn(filePath: string): Record<string, unknown> | null {
+  const doc = parse(readFileSync(filePath, "utf8")) as
+    | Record<string | boolean, unknown>
+    | null;
+  if (!doc || typeof doc !== "object") return null;
+  // YAML 1.1 may parse a bare `on:` key as boolean true.
+  const on = doc.on ?? doc[true];
+  if (!on || typeof on !== "object" || Array.isArray(on)) return null;
+  return on as Record<string, unknown>;
+}
+
+type PullRequestFilter =
+  | { kind: "unfiltered" }
+  | { kind: "paths-ignore"; paths: string[] }
+  | { kind: "paths"; paths: string[] };
+
+function pullRequestFilterCoverage(pr: unknown): PullRequestFilter {
+  if (pr == null) {
+    return { kind: "unfiltered" };
+  }
+  if (typeof pr !== "object" || Array.isArray(pr)) {
+    // `pull_request:` bare form means no path filter.
+    return { kind: "unfiltered" };
+  }
+
+  const record = pr as Record<string, unknown>;
+  if (Array.isArray(record["paths-ignore"])) {
+    return {
+      kind: "paths-ignore",
+      paths: record["paths-ignore"].map(String),
+    };
+  }
+
+  if (Array.isArray(record.paths)) {
+    return { kind: "paths", paths: record.paths.map(String) };
+  }
+
+  return { kind: "unfiltered" };
+}
+
+function globMatch(pattern: string, path: string): boolean {
+  // Minimal support for the `**` / `*` patterns used in workflow path filters.
+  const escaped = pattern
+    .replace(/[.+^${}()|[\]\\]/g, "\\$&")
+    .replace(/\*\*/g, "::DOUBLE::")
+    .replace(/\*/g, "[^/]*")
+    .replace(/::DOUBLE::/g, ".*");
+  return new RegExp(`^${escaped}$`).test(path);
+}
+
+function isCovered(filter: PullRequestFilter, releasePath: string): boolean {
+  if (filter.kind === "unfiltered") return false;
+
+  if (filter.kind === "paths-ignore") {
+    return filter.paths.includes(releasePath);
+  }
+
+  // paths allow-list: a release path is "covered" (will not create a run on its
+  // own) when no positive pattern matches it, or a later negation excludes it.
+  let matched = false;
+  for (const pattern of filter.paths) {
+    if (pattern.startsWith("!")) {
+      const negated = pattern.slice(1);
+      if (
+        matched &&
+        (negated === releasePath || globMatch(negated, releasePath))
+      ) {
+        matched = false;
+      }
+      continue;
+    }
+    if (pattern === releasePath || globMatch(pattern, releasePath)) {
+      matched = true;
+    }
+  }
+  // Covered means the path does NOT cause the workflow to run.
+  return !matched;
+}
+
+describe("release-please CI exclusions", () => {
+  const expected = expectedReleaseOutputs();
+
+  it("derives the node release-output set for this repository", () => {
+    expect(expected).toEqual([
+      "CHANGELOG.md",
+      "package.json",
+      ".release-please-manifest.json",
+    ]);
+  });
+
+  it("every pull_request workflow ignores the full release-output set", () => {
+    const files = readdirSync(workflowsDir).filter((name) =>
+      name.endsWith(".yml"),
+    );
+    const prWorkflows: { name: string; filter: PullRequestFilter }[] = [];
+
+    for (const name of files) {
+      const filePath = join(workflowsDir, name);
+      const on = loadWorkflowOn(filePath);
+      if (!on || !("pull_request" in on)) continue;
+      prWorkflows.push({
+        name,
+        filter: pullRequestFilterCoverage(on.pull_request),
+      });
+    }
+
+    expect(prWorkflows.map((w) => w.name).sort()).toEqual([
+      "ci.yml",
+      "guard-generated-files.yml",
+      "no-mistakes-required.yml",
+    ]);
+
+    const failures: string[] = [];
+    for (const { name, filter } of prWorkflows) {
+      const missing = expected.filter((path) => !isCovered(filter, path));
+      if (missing.length > 0) {
+        failures.push(`${name} missing coverage for: ${missing.join(", ")}`);
+      }
+    }
+
+    expect(failures).toEqual([]);
+  });
+
+  it("does not attach path filters to non-pull_request triggers on ci.yml", () => {
+    const on = loadWorkflowOn(join(workflowsDir, "ci.yml"));
+    expect(on).not.toBeNull();
+    expect(on!.push).toEqual({ branches: ["main"] });
+    const pr = on!.pull_request as Record<string, unknown>;
+    expect(pr.branches).toEqual(["main"]);
+    expect(pr["paths-ignore"]).toEqual([
+      ".release-please-manifest.json",
+      "CHANGELOG.md",
+      "package.json",
+    ]);
+    expect(on!.release).toBeUndefined();
+    expect(on!.workflow_dispatch).toBeUndefined();
+  });
+
+  it("keeps bot author exemptions on guard and no-mistakes jobs", () => {
+    const guard = readFileSync(
+      join(workflowsDir, "guard-generated-files.yml"),
+      "utf8",
+    );
+    const nmr = readFileSync(
+      join(workflowsDir, "no-mistakes-required.yml"),
+      "utf8",
+    );
+    expect(guard).toContain("github-actions[bot]");
+    expect(guard).toContain("release-please[bot]");
+    expect(nmr).toContain("github-actions[bot]");
+    expect(nmr).toContain("dependabot[bot]");
+    expect(nmr).toContain("release-please[bot]");
+  });
+});


### PR DESCRIPTION
## Summary

Stop creating `pull_request` workflow runs for release-please PRs.

GitHub now creates `action_required` runs when release-please opens a PR with `GITHUB_TOKEN`. Job-level bot `if`s cannot prevent that. Path filtering does: when every changed file is in `paths-ignore`, no run is created.

### Changes
- `ci.yml`, `guard-generated-files.yml`, `no-mistakes-required.yml`: add `pull_request.paths-ignore` for `.release-please-manifest.json`, `CHANGELOG.md`, `package.json`
- Keep existing bot author job conditions as defense in depth
- Add `test/release-ci-exclusions.test.ts` that derives the expected output set from `release-please-config.json` and asserts every `pull_request` workflow covers it
- Document the contract in `AGENTS.md`

### Validation
- YAML parse of all three workflows: `paths-ignore` under `pull_request` only; `push` on `ci.yml` unchanged
- Focused drift test: 4/4 pass
- Offline filter against latest release PR #23 (files: manifest, CHANGELOG, package.json): fully covered → zero runs
- Offline filter against 8 recent human PRs: all still trigger CI

### Notes for merge
Direct-PR delivery per captain override for this release-please CI rollout. A red `Require no-mistakes` check is expected and is not a merge blocker (no required status checks on this repo). Do not merge any open release PR as part of this work.

