### PR TITLE
fix(cli): speed up standalone version queries

### DIFF
--- a/.no-mistakes/evidence/fm/tasksaxi-version-fastpath-adopt-p4/cli-transcript.txt
+++ b/.no-mistakes/evidence/fm/tasksaxi-version-fastpath-adopt-p4/cli-transcript.txt
@@ -1,0 +1,29 @@
+End-user CLI verification
+
+$ node --import tsx bin/tasks-axi.ts -v
+0.2.4
+exit: 0
+
+$ node --import tsx bin/tasks-axi.ts -V
+0.2.4
+exit: 0
+
+$ node --import tsx bin/tasks-axi.ts --version
+0.2.4
+exit: 0
+
+$ node --import tsx bin/tasks-axi.ts list --version
+error: "Unknown flag: --version"
+code: VALIDATION_ERROR
+help[1]: Run the command with --help to see supported flags
+exit: 2
+
+Module-trace verification for the bare --version invocation
+
+present: src/version.ts
+present: axi-sdk-js/dist/fast-path.js
+absent: src/cli.ts
+absent: @toon-format modules
+absent: axi-sdk-js/dist/index.js
+
+The complete loader-produced trace is in version-module-trace.txt.

--- a/.no-mistakes/evidence/fm/tasksaxi-version-fastpath-adopt-p4/version-module-trace.txt
+++ b/.no-mistakes/evidence/fm/tasksaxi-version-fastpath-adopt-p4/version-module-trace.txt
@@ -1,0 +1,3 @@
+file:///Users/kunchen/.no-mistakes/worktrees/4ebfb4ced0b4/01KZD5GTT42WND2KE5SZK4D5Y5/bin/tasks-axi.ts
+file:///Users/kunchen/.no-mistakes/worktrees/4ebfb4ced0b4/01KZD5GTT42WND2KE5SZK4D5Y5/node_modules/.pnpm/axi-sdk-js@0.1.10/node_modules/axi-sdk-js/dist/fast-path.js
+file:///Users/kunchen/.no-mistakes/worktrees/4ebfb4ced0b4/01KZD5GTT42WND2KE5SZK4D5Y5/src/version.ts

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,13 @@ The CLI layer never knows which backend is active — it only talks to the `Stor
   This lets an agent confirm a write deterministically without a follow-up read.
   Errors still use structured-error output + non-zero exit (not JSON), so `exit 0` + `ok:true` = success.
 
+## Entry point & the `--version` fast path
+
+`bin/tasks-axi.ts` answers a bare `-v`/`-V`/`--version` through `axi-sdk-js/fast-path` and only then `await import`s `src/cli.js`, so the heavy command graph never loads for a version query (~31ms -> ~20ms, the node floor).
+That makes `src/version.ts` a **leaf**: it may import node builtins and nothing else - importing anything from the command graph silently destroys the speedup. `cli.ts` re-imports `VERSION` from it, so there is still one source of the version string.
+Any argv shape other than exactly one version flag falls through to `runAxiCli`, which remains the sole owner of the general case (e.g. `list --version` is still an unknown-flag error).
+`test/bin/version-fast-path.test.ts` guards this deterministically with an ESM loader module trace (`test/fixtures/module-trace-*.mjs`) plus a negative control; do **not** add a wall-clock timing assertion to CI - it is flaky under runner contention.
+
 ## Build / test / ship
 
 - `pnpm build` (tsc), `pnpm test` (vitest, `test/` mirrors `src/`), `pnpm lint` (eslint), `pnpm run build:skill -- --check` (the generated `skills/tasks-axi/SKILL.md` is built from `DESCRIPTION` + `TOP_HELP` and must not drift — CI runs the check).

--- a/bin/tasks-axi.ts
+++ b/bin/tasks-axi.ts
@@ -1,4 +1,8 @@
 #!/usr/bin/env node
-import { main } from "../src/cli.js";
+import { tryFastPath } from "axi-sdk-js/fast-path";
+import { VERSION } from "../src/version.js";
 
-main();
+if (!tryFastPath(process.argv.slice(2), { version: VERSION })) {
+  const { main } = await import("../src/cli.js");
+  await main();
+}

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   },
   "dependencies": {
     "@toon-format/toon": "^2.1.0",
-    "axi-sdk-js": "^0.1.7"
+    "axi-sdk-js": "^0.1.10"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^2.1.0
         version: 2.3.0
       axi-sdk-js:
-        specifier: ^0.1.7
-        version: 0.1.7
+        specifier: ^0.1.10
+        version: 0.1.10
     devDependencies:
       '@eslint/js':
         specifier: ^10.0.1
@@ -686,8 +686,8 @@ packages:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
-  axi-sdk-js@0.1.7:
-    resolution: {integrity: sha512-kzIeuQHZx3FFpzJknq+sdbi3XBGdyPGMdOHM2Zepa4MF5MpckhPeWPd5x+RX6gBKEWZdaW73YrOPY+HAGyLekw==}
+  axi-sdk-js@0.1.10:
+    resolution: {integrity: sha512-mktHOya6qUgqDcMpmj5WsNDzArre15N2qfns8bY98nrHGTSqdBnH2Ok77c2zOA2jYbGHO/BhhVZtDGK/UTO70g==}
     engines: {node: '>=20'}
 
   balanced-match@4.0.4:
@@ -1597,7 +1597,7 @@ snapshots:
 
   assertion-error@2.0.1: {}
 
-  axi-sdk-js@0.1.7:
+  axi-sdk-js@0.1.10:
     dependencies:
       '@toon-format/toon': 2.3.0
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,3 @@
-import { existsSync, readFileSync } from "node:fs";
-import { dirname, join } from "node:path";
-import { fileURLToPath } from "node:url";
 import { runAxiCli } from "axi-sdk-js";
 import {
   requireFlagValue,
@@ -53,11 +50,10 @@ import {
 } from "./commands/public-followup.js";
 import { SETUP_HELP, setupCommand } from "./commands/setup.js";
 import type { SuggestionGlobals } from "./suggestions.js";
+import { VERSION } from "./version.js";
 
 export const DESCRIPTION =
   "Agent ergonomic task & backlog manager for the current workspace. Prefer this over hand-editing backlog.md for task state, dependency, or hold changes.";
-
-const VERSION = readPackageVersion();
 
 type CliStdout = Pick<NodeJS.WriteStream, "write">;
 
@@ -237,28 +233,4 @@ function parseGlobalFlags(args: string[]): {
 
 function requireNonEmptyGlobalFlagValue(flag: string, value: string): string {
   return requireNonEmptySingleLineFlagValue(flag, value) ?? value;
-}
-
-function readPackageVersion(): string {
-  const here = dirname(fileURLToPath(import.meta.url));
-
-  for (const candidate of [
-    join(here, "..", "package.json"),
-    join(here, "..", "..", "package.json"),
-  ]) {
-    if (!existsSync(candidate)) continue;
-    const parsed = JSON.parse(readFileSync(candidate, "utf-8")) as {
-      version?: unknown;
-      name?: unknown;
-    };
-    if (
-      parsed.name === "tasks-axi" &&
-      typeof parsed.version === "string" &&
-      parsed.version.length > 0
-    ) {
-      return parsed.version;
-    }
-  }
-
-  throw new Error("Could not determine tasks-axi package version");
 }

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,0 +1,36 @@
+/**
+ * Leaf module: the package version, resolved from `package.json`.
+ *
+ * This file must import ONLY node builtins. `bin/tasks-axi.ts` imports it
+ * eagerly so `--version` can be answered before the heavy command graph in
+ * `cli.ts` is dynamically imported.
+ */
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+function readPackageVersion(): string {
+  const here = dirname(fileURLToPath(import.meta.url));
+
+  for (const candidate of [
+    join(here, "..", "package.json"),
+    join(here, "..", "..", "package.json"),
+  ]) {
+    if (!existsSync(candidate)) continue;
+    const parsed = JSON.parse(readFileSync(candidate, "utf-8")) as {
+      version?: unknown;
+      name?: unknown;
+    };
+    if (
+      parsed.name === "tasks-axi" &&
+      typeof parsed.version === "string" &&
+      parsed.version.length > 0
+    ) {
+      return parsed.version;
+    }
+  }
+
+  throw new Error("Could not determine tasks-axi package version");
+}
+
+export const VERSION = readPackageVersion();

--- a/test/bin/version-fast-path.test.ts
+++ b/test/bin/version-fast-path.test.ts
@@ -1,0 +1,107 @@
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+/**
+ * `bin/tasks-axi.ts` answers a bare version flag through
+ * `axi-sdk-js/fast-path` + the leaf `src/version.ts`, and only dynamically
+ * imports `src/cli.ts` for everything else. These guards are deterministic:
+ * they assert the module graph actually loaded, not wall-clock time.
+ */
+
+const REPO_ROOT = fileURLToPath(new URL("../..", import.meta.url));
+const BIN = join(REPO_ROOT, "bin", "tasks-axi.ts");
+const REGISTER = fileURLToPath(
+  new URL("../fixtures/module-trace-register.mjs", import.meta.url),
+);
+
+const { version: PKG_VERSION } = JSON.parse(
+  readFileSync(join(REPO_ROOT, "package.json"), "utf8"),
+) as { version: string };
+
+let traceDir: string;
+let nextTrace = 0;
+
+beforeAll(() => {
+  traceDir = mkdtempSync(join(tmpdir(), "tasks-axi-trace-"));
+});
+
+afterAll(() => {
+  rmSync(traceDir, { recursive: true, force: true });
+});
+
+interface Run {
+  stdout: string;
+  status: number | null;
+  loaded: string[];
+}
+
+function run(args: string[]): Run {
+  const tracePath = join(traceDir, `trace-${nextTrace++}.txt`);
+  const result = spawnSync(
+    process.execPath,
+    ["--import", "tsx", "--import", REGISTER, BIN, ...args],
+    {
+      cwd: REPO_ROOT,
+      encoding: "utf8",
+      env: { ...process.env, AXI_MODULE_TRACE: tracePath },
+    },
+  );
+
+  const trace = readFileSync(tracePath, "utf8");
+  return {
+    stdout: result.stdout,
+    status: result.status,
+    loaded: trace.split("\n").filter((line) => line.length > 0),
+  };
+}
+
+const loadedHeavyGraph = (loaded: string[]): boolean =>
+  loaded.some((url) => url.endsWith("/src/cli.ts"));
+
+describe("version fast path", () => {
+  it.each(["-v", "-V", "--version"])(
+    "prints exactly the package version for %s and skips the command graph",
+    (flag) => {
+      const { stdout, status, loaded } = run([flag]);
+
+      expect(stdout).toBe(`${PKG_VERSION}\n`);
+      expect(status).toBe(0);
+
+      // Only the bin, the SDK fast path, and the leaf version module load.
+      expect(loadedHeavyGraph(loaded)).toBe(false);
+      expect(
+        loaded.filter((url) => url.includes("/@toon-format/")),
+      ).toHaveLength(0);
+      expect(
+        loaded.filter((url) => url.endsWith("/axi-sdk-js/dist/index.js")),
+      ).toHaveLength(0);
+      expect(loaded.some((url) => url.endsWith("/src/version.ts"))).toBe(true);
+      expect(loaded.some((url) => url.endsWith("/fast-path.js"))).toBe(true);
+    },
+  );
+
+  // Negative control: the probe above is only meaningful if it would notice
+  // the heavy graph being loaded. These argv shapes deliberately fall through
+  // to `runAxiCli`, and the trace must show it.
+  it.each([["--help"], ["list", "--help"], ["list", "--version"]])(
+    "still loads the command graph for %s",
+    (...args: string[]) => {
+      const { loaded } = run(args);
+
+      expect(loadedHeavyGraph(loaded)).toBe(true);
+    },
+  );
+
+  it("leaves a trailing version flag to the full CLI, unchanged", () => {
+    // Pre-change behaviour: `runAxiCli` owns the general case and rejects a
+    // version flag in a command position. The fast path must not swallow it.
+    const { stdout, status } = run(["list", "--version"]);
+
+    expect(stdout).toContain('error: "Unknown flag: --version"');
+    expect(status).not.toBe(0);
+  });
+});

--- a/test/bin/version-fast-path.test.ts
+++ b/test/bin/version-fast-path.test.ts
@@ -14,9 +14,10 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 const REPO_ROOT = fileURLToPath(new URL("../..", import.meta.url));
 const BIN = join(REPO_ROOT, "bin", "tasks-axi.ts");
-const REGISTER = fileURLToPath(
-  new URL("../fixtures/module-trace-register.mjs", import.meta.url),
-);
+const REGISTER = new URL(
+  "../fixtures/module-trace-register.mjs",
+  import.meta.url,
+).href;
 
 const { version: PKG_VERSION } = JSON.parse(
   readFileSync(join(REPO_ROOT, "package.json"), "utf8"),

--- a/test/fixtures/module-trace-hook.mjs
+++ b/test/fixtures/module-trace-hook.mjs
@@ -1,0 +1,16 @@
+// ESM loader hook: appends the URL of every module the process loads to the
+// file named by the registration `data.out`. Used by
+// `test/bin/version-fast-path.test.ts` to prove the heavy command graph is not
+// loaded on the `--version` fast path.
+import { appendFileSync } from "node:fs";
+
+let out;
+
+export function initialize(data) {
+  out = data.out;
+}
+
+export async function load(url, context, next) {
+  if (out) appendFileSync(out, `${url}\n`);
+  return next(url, context);
+}

--- a/test/fixtures/module-trace-register.mjs
+++ b/test/fixtures/module-trace-register.mjs
@@ -1,0 +1,7 @@
+// Registers `module-trace-hook.mjs` for the process it is `--import`ed into.
+// The trace destination comes from `AXI_MODULE_TRACE`.
+import { register } from "node:module";
+
+register(new URL("./module-trace-hook.mjs", import.meta.url).href, {
+  data: { out: process.env.AXI_MODULE_TRACE },
+});


### PR DESCRIPTION
## Intent

Adopt the axi-sdk-js/fast-path in tasks-axi so `tasks-axi --version` hits the node floor (~31ms -> ~20ms), per the shared spec at /Users/kunchen/fm-homes/axi-a1/data/p4-fastpath-adoption-spec.md.

Required work:
1. Bump the axi-sdk-js dependency range to include 0.1.10 (so the dependency-free `axi-sdk-js/fast-path` subpath export resolves) and install.
2. tasks-axi computed its version inside src/cli.ts (a readPackageVersion() helper). Extract it into a LEAF src/version.ts that imports ONLY node builtins - never the heavy command graph - and re-import VERSION from it in cli.ts, so there is still one source of the version string.
3. Rewrite bin/tasks-axi.ts to the exact benchmarked fast-path shape: import tryFastPath from axi-sdk-js/fast-path and VERSION from the leaf module; if tryFastPath(process.argv.slice(2), {version: VERSION}) returns false, `await import("../src/cli.js")` (dynamic, so the heavy graph loads only there) and await main().
4. Keep the fast path conservative: exactly one argv element that is -v/-V/--version. Any other form (including a version flag in a trailing position such as `list --version`) falls through to runAxiCli, which remains the sole owner of the general case - `list --version` is still an unknown-flag validation error, exactly as before.

Hard constraints from the requester: firstmate's own backlog runs on tasks-axi, so `--version` output must stay byte-identical and NO command behavior may change - this is only the version fast path.

Regression-test approach mandated by the spec (deliberate decisions, not oversights):
- A deterministic module-trace guard: an ESM loader hook (test/fixtures/module-trace-*.mjs) records every module URL the spawned bin process loads, and test/bin/version-fast-path.test.ts asserts src/cli.ts, axi-sdk-js/dist/index.js and @toon-format are absent on the --version path while the fast-path module and the leaf version module are present.
- A NEGATIVE CONTROL proving the probe would catch a regression: --help, `list --help` and `list --version` must each still load the heavy graph.
- Flag parity: -v, -V and --version each print exactly `${version}\n` and exit 0, matching the pre-change output byte-for-byte.
- DELIBERATELY NO wall-clock timing assertion in CI (neither absolute nor delta). A sibling task proved that flaky across CI runners (15ms and 30ms budgets both failed under contention). The module trace deterministically proves the heavy graph is skipped, which is the real mechanism of the speedup and the correct thing to assert. Do not add a timing gate.

The tests spawn the TypeScript bin via `node --import tsx --import <register> bin/tasks-axi.ts` rather than the built dist output, so the guard runs without requiring a prior build and exercises the sources under test.

AXI ergonomics must be preserved (per the `axi` skill). AGENTS.md gained a short 'Entry point & the --version fast path' section recording the leaf-module invariant and the no-timing-in-CI rule.

## What Changed

- Route standalone `-v`, `-V`, and `--version` requests through `axi-sdk-js/fast-path`, deferring the full CLI command graph for all other arguments.
- Extract package-version resolution into a Node-only leaf module and update `axi-sdk-js` to `^0.1.10`.
- Add deterministic module-trace coverage for fast-path isolation, version-output parity, and full-CLI fallthrough behavior.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>
</details>
<details>
<summary>✅ **Rebase** - passed</summary>
</details>
<details>
<summary>✅ **Review** - completed</summary>
</details>
<details>
<summary>✅ **Test** - passed</summary>
</details>
<details>
<summary>✅ **Document** - passed</summary>
</details>
<details>
<summary>✅ **Lint** - passed</summary>
</details>
<details>
<summary>✅ **Push** - passed</summary>
</details>
