### PR TITLE
feat: accept Gitea /pulls/<n> URLs in done --pr

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ tasks-axi add lavish-foo-q9 "fix summary toggle" --kind ship --repo lavish-axi -
 # move through the workflow
 tasks-axi start firstmate-lease-adopt
 tasks-axi done sm-idle-handoff-q8 --pr https://github.com/owner/repo/pull/42
+tasks-axi done sm-idle-handoff-q8 --pr https://git.example.com/owner/repo/pulls/42
 tasks-axi reopen some-task
 
 # dependencies, holds, and the ready queue

--- a/src/backends/markdown-grammar.ts
+++ b/src/backends/markdown-grammar.ts
@@ -125,7 +125,7 @@ const TAIL_HOLD_KIND = new RegExp(
 );
 const TAIL_HOLD_UNTIL = new RegExp(`\\s*\\(hold-until:\\s*(${DATE})\\)\\s*$`);
 
-const PR_LINK = /https?:\/\/\S+?\/pull\/\d+/g;
+const PR_LINK = /https?:\/\/\S+?\/pulls?\/\d+/g;
 const REPORT_LINK = /\bdata\/\S+?\/report\.md\b/g;
 const GENERIC_URL = /https?:\/\/\S+/g;
 
@@ -165,7 +165,7 @@ export function deriveLinks(text: string): TaskLink[] {
   for (const m of text.matchAll(PR_LINK)) add("pr", m[0]);
   for (const m of text.matchAll(REPORT_LINK)) add("report", m[0]);
   for (const m of text.matchAll(GENERIC_URL)) {
-    if (!/\/pull\/\d+/.test(m[0])) add("doc", m[0]);
+    if (!/\/pulls?\/\d+/.test(m[0])) add("doc", m[0]);
   }
   return links;
 }

--- a/src/backends/markdown.ts
+++ b/src/backends/markdown.ts
@@ -149,7 +149,7 @@ function normalizeTypedLink(link: TaskLink): TaskLink {
   ) {
     const expected =
       link.kind === "pr"
-        ? "an http(s) pull request URL ending in /pull/<number>"
+        ? "an http(s) pull request URL ending in /pull/<number> or /pulls/<number>"
         : link.kind === "report"
           ? "a data/<id>/report.md path"
           : "an http(s) URL";

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -73,6 +73,7 @@ examples:
   tasks-axi list --state queued
   tasks-axi show homemux-h7 --full
   tasks-axi done sm-idle-handoff-q8 --pr https://github.com/o/r/pull/42
+  tasks-axi done sm-idle-handoff-q8 --pr https://git.itken.icu/cashew/app/pulls/42
   tasks-axi block fm-x --by treehouse-lease-t4
   tasks-axi hold fm-x --reason "captain decision pending" --kind captain
   tasks-axi ready

--- a/src/commands/crud.ts
+++ b/src/commands/crud.ts
@@ -146,7 +146,7 @@ function requireTypedLinkUrl(
   ) {
     const expected =
       kind === "pr"
-        ? "an http(s) pull request URL ending in /pull/<number>"
+        ? "an http(s) pull request URL ending in /pull/<number> or /pulls/<number>"
         : "a data/<id>/report.md path";
     throw new AxiError(`${flag} must be ${expected}`, "VALIDATION_ERROR");
   }

--- a/src/commands/state.ts
+++ b/src/commands/state.ts
@@ -57,6 +57,7 @@ flags:
   --json   print the resulting task as a JSON object
 examples:
   tasks-axi done sm-idle-handoff-q8 --pr https://github.com/o/r/pull/42
+  tasks-axi done sm-idle-handoff-q8 --pr https://git.itken.icu/cashew/app/pulls/42
   tasks-axi done pr31-review-r6 --report data/pr31-review-r6/report.md`;
 
 export const REOPEN_HELP = `usage: tasks-axi reopen <id>

--- a/test/backends/markdown-grammar.test.ts
+++ b/test/backends/markdown-grammar.test.ts
@@ -326,6 +326,18 @@ describe("markdown grammar", () => {
       });
       expect(links).toContainEqual({ kind: "report", url: "data/x/report.md" });
     });
+
+    it("derives a pr link from a Gitea /pulls/ URL, never a doc link", () => {
+      const links = deriveLinks("shipped https://git.itken.icu/o/r/pulls/42");
+      expect(links).toContainEqual({
+        kind: "pr",
+        url: "https://git.itken.icu/o/r/pulls/42",
+      });
+      expect(links).not.toContainEqual({
+        kind: "doc",
+        url: "https://git.itken.icu/o/r/pulls/42",
+      });
+    });
   });
 
   describe("canonical render", () => {

--- a/test/backends/markdown.test.ts
+++ b/test/backends/markdown.test.ts
@@ -485,6 +485,26 @@ describe("MarkdownStore", () => {
       }
     });
 
+    it("folds an added Gitea pr link into the prose and re-derives links", async () => {
+      const b = makeBacklog();
+      try {
+        const { task } = await b.store.update("cert-cleanup", {
+          addLinks: [
+            { kind: "pr", url: "https://git.itken.icu/cashew/app/pulls/9" },
+          ],
+        });
+        expect(task.links).toContainEqual({
+          kind: "pr",
+          url: "https://git.itken.icu/cashew/app/pulls/9",
+        });
+        expect(b.read()).toContain(
+          "https://git.itken.icu/cashew/app/pulls/9",
+        );
+      } finally {
+        b.cleanup();
+      }
+    });
+
     it("dedupes added links by exact parsed url, not substring", async () => {
       const b = makeBacklog(
         "# Backlog\n\n## Queued\n- [ ] task-q1 - title https://github.com/o/r/pull/10\n\n## Done\n",
@@ -746,6 +766,26 @@ describe("MarkdownStore", () => {
         expect(task.closed).toBe("2026-07-01");
         const read = b.read();
         expect(read).toContain("https://github.com/o/r/pull/7");
+        expect(read).toContain("(merged 2026-07-01)");
+      } finally {
+        b.cleanup();
+      }
+    });
+
+    it("moves to done, records a Gitea pr link and a merged stamp", async () => {
+      const b = makeBacklog();
+      try {
+        const task = await b.store.transition("cert-cleanup", "done", {
+          pr: "https://git.itken.icu/cashew/app/pulls/7",
+        });
+        expect(task.state).toBe("done");
+        expect(task.links).toContainEqual({
+          kind: "pr",
+          url: "https://git.itken.icu/cashew/app/pulls/7",
+        });
+        expect(task.closed).toBe("2026-07-01");
+        const read = b.read();
+        expect(read).toContain("https://git.itken.icu/cashew/app/pulls/7");
         expect(read).toContain("(merged 2026-07-01)");
       } finally {
         b.cleanup();

--- a/test/commands/crud.test.ts
+++ b/test/commands/crud.test.ts
@@ -348,6 +348,26 @@ describe("crud commands", () => {
       }
     });
 
+    it("records a Gitea pr link on add", async () => {
+      const b = makeBacklog();
+      try {
+        await addCommand(
+          [
+            "new-q1",
+            "linked task",
+            "--pr",
+            "https://git.itken.icu/cashew/app/pulls/9",
+          ],
+          b.ctx,
+        );
+        expect(b.read()).toContain(
+          "https://git.itken.icu/cashew/app/pulls/9",
+        );
+      } finally {
+        b.cleanup();
+      }
+    });
+
     it("rejects an empty link flag before creating a task", async () => {
       const b = makeBacklog();
       try {

--- a/test/commands/state.test.ts
+++ b/test/commands/state.test.ts
@@ -125,6 +125,29 @@ describe("state commands", () => {
       }
     });
 
+    it("closes with a Gitea pull URL and records it as the pr link", async () => {
+      const b = makeBacklog();
+      try {
+        const out = await doneCommand(
+          [
+            "cert-cleanup",
+            "--pr",
+            "https://git.itken.icu/cashew/app/pulls/42",
+            "--no-prune",
+          ],
+          b.ctx,
+        );
+        expect(out).toContain(
+          "done cert-cleanup -> Done (pr https://git.itken.icu/cashew/app/pulls/42)",
+        );
+        const read = b.read();
+        expect(read).toContain("https://git.itken.icu/cashew/app/pulls/42");
+        expect(read).toContain("(merged 2026-07-01)");
+      } finally {
+        b.cleanup();
+      }
+    });
+
     it("emits a machine-readable task and pruned count with --json", async () => {
       const b = makeBacklog();
       try {


### PR DESCRIPTION
## What

Extends `tasks-axi done --pr` to accept Gitea pull-request URLs. Gitea hosts PRs under `/pulls/<N>` while GitHub uses `/pull/<N>`.

This unblocks `done --pr` for Gitea-hosted PRs (Cashew/Sajed use git.itken.icu).

## Changes

- `src/backends/markdown-grammar.ts`: `PR_LINK` now matches both `/pull/<N>` and `/pulls/<N>` (`/pulls?/`), and the generic-URL fallback no longer classifies a Gitea PR URL as a `doc` link. This is the single source of truth for PR-link recognition, so `done --pr`, `add --pr`, and `update --add-links` all accept Gitea URLs and record them as `pr` links.
- Updated the "must be a pull request URL" validation messages in `crud.ts` and `markdown.ts` to document both forms.
- Updated the `done` help examples (`state.ts`, `cli.ts`) and the README with a Gitea example.
- Added tests: `done --pr` (state), add with `--pr` (crud), grammar derivation incl. no-doc-link regression, backend transition and add-links with Gitea URLs.

## Validation

- `pnpm build`, `pnpm lint`, `pnpm test` (396 passed, 1 skipped), `pnpm run build:skill -- --check` all pass.
- Manual CLI check: Gitea `/pulls/42` accepted and stored as `links: pr:.../pulls/42`; GitHub `/pull/7` still works; `/issues/42` still rejected with the updated message.
