### PR TITLE
fix(store): decide already-vs-fresh transitions inside the backlog lock

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,7 @@ The CLI layer never knows which backend is active — it only talks to the `Stor
 - `src/cli.ts` — `runAxiCli` wiring: `DESCRIPTION`, `TOP_HELP`, the verb→handler map (with aliases create/view/edit/delete/close), the optional `task` noun prefix, and the global `--backend` / `--file` flags (stripped before handlers, parsed for `resolveContext`).
 - `src/context.ts` — `resolveTasksContext` builds the backend `Store` + `ResolvedConfig`; every command receives this `TasksContext`.
 - `src/store.ts` - the `Store` interface and `Capabilities`. Core contract: `create/get/update/remove/list/transition/addDep/removeDep/updatePublicFollowup`. `prune`/`render` are optional and capability-gated.
+  `transition` returns `{ task, already, changed }`, and every backend must derive `already` from a reread **inside** its own critical section - deciding it from a caller-side pre-lock read is a TOCTOU that lets concurrent callers both claim the same transition. Commands only render the result.
 - `src/model.ts` — the `Task` data model (report §5).
 - `src/pr-url.ts` — `isPrUrl`, the one canonical PR-URL seam (GitHub `/pull/<n>` on github.com, Forgejo `/pulls/<n>` on any lowercase DNS host) shared by prose link derivation, `--pr` validation, and public-followup `pr_url`; near-misses derive as `doc` links, never `pr`.
 - `src/derive.ts` - worker `blocked` / `ready` / active `held` and public delivery readiness are derived in the CLI from `list` + the dep graph + hold date gates, never Store methods, so every backend gets them for free.
@@ -35,6 +36,7 @@ The CLI layer never knows which backend is active — it only talks to the `Stor
   The grammar validates it strictly on every read, excludes it from the human body, and re-emits it through render, move, transition, prune, and archive.
   Firstmate and other callers must use `tasks-axi public-followup` and `--json`, never parse or rewrite the comment.
   Generic worker readiness and lifecycle transitions cannot dispatch, complete, reopen, remove, or change the kind of an active obligation; only a posted receipt or Captain waiver completes it.
+  That transition guard keys off whether the call would actually mutate, so a pure no-op (e.g. `reopen` on a queued obligation) stays the idempotent `already: true` success it is for every other verb, while any state, link, or note write still fails closed.
 - **Concurrency:** every mutation runs under `withLock` (advisory `<path>.lock`) and fails closed with a `LOCKED` error if another process holds the lock past the bounded timeout.
   If the lock looks stale, the error tells the user to remove `<path>.lock` only after confirming no `tasks-axi` process is running.
   Corruption-safety is guaranteed independently by atomic temp-file + rename writes, and a hand-edit landing between read and write is detected and refused.

--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ The long task body is truncated by default — the whole point is that `list` st
 `--archive-body` preserves the replaced body in `note-archive.md` using the same dated markdown archive block style as done pruning.
 Every write leads with a terse `ok:` line confirming the write result, including the resulting task state when the command changes one (e.g. `ok: start lavish-share -> In flight`, `ok: done grok-harness-g7 -> Done (pr <url>)`, `ok: render -> normalized 3`), followed by state-aware next-step hints that never suggest an action the command just performed.
 Mutations are idempotent and report what changed (`already: true` on a no-op), so re-running one is safe.
+`start`, `done`, and `reopen` decide already-vs-fresh under the backlog lock, so when several processes race the same task exactly one reports the fresh transition and the rest report `already: true`.
 Running `done` again on an already Done task can still backfill a new `--pr`, `--report`, or `--note` without changing the original close date.
 `hold <id> --reason "<text>"` records an intentional pause without turning it into prose, and `unhold <id>` clears it.
 The reason must be single-line text without parentheses because parentheses are reserved for canonical markdown tags.

--- a/src/backends/markdown.ts
+++ b/src/backends/markdown.ts
@@ -38,6 +38,7 @@ import type {
   Capabilities,
   PruneOptions,
   PruneResult,
+  TransitionResult,
   Store,
 } from "../store.js";
 import { atomicWrite, readFileSafe, withLock, withLocks } from "./lock.js";
@@ -957,7 +958,7 @@ export class MarkdownStore implements Store {
     id: string,
     to: State,
     opts: TransitionOpts = {},
-  ): Promise<Task> {
+  ): Promise<TransitionResult> {
     return withLock(this.path, () => {
       const loaded = this.loadForUpdate();
       const { doc } = loaded;
@@ -977,6 +978,12 @@ export class MarkdownStore implements Store {
       }
       const date = normalizeDate(opts.date ?? this.now(), "transition date");
 
+      // The already/fresh decision is made HERE, on the freshly reread task
+      // inside the critical section. Deciding it from a caller's pre-lock read
+      // let two concurrent callers both claim they performed the transition.
+      const already = task.state === to;
+      let changed = false;
+
       // Record links / notes before stamping so closureVerb sees them.
       const transitionLinks: TaskLink[] = [];
       if (opts.pr !== undefined) {
@@ -986,32 +993,53 @@ export class MarkdownStore implements Store {
         transitionLinks.push({ kind: "report", url: opts.report });
       }
       for (const link of transitionLinks) {
-        task.title = appendTitleLink(task.title, link);
+        const title = appendTitleLink(task.title, link);
+        if (title !== task.title) {
+          task.title = title;
+          changed = true;
+        }
       }
-      if (opts.note) {
-        task.body = task.body ? `${task.body}\n${opts.note}` : opts.note;
+      if (opts.note && !bodyHasLine(task.body, opts.note)) {
+        task.body = addBodyLine(task.body, opts.note);
+        changed = true;
       }
       task.links = deriveLinks(task.title);
 
-      task.state = to;
-      if (to === "done") {
-        task.closed = date;
-      } else if (to === "in_flight") {
-        if (!task.created) task.created = date;
-        task.closed = undefined;
-      } else {
-        task.closed = undefined;
+      // An already-terminal task keeps its original closed date; only the
+      // supplied metadata is backfilled.
+      if (!already) {
+        task.state = to;
+        if (to === "done") {
+          task.closed = date;
+        } else if (to === "in_flight") {
+          if (!task.created) task.created = date;
+          task.closed = undefined;
+        } else {
+          task.closed = undefined;
+        }
+        changed = true;
       }
+
+      // A pure no-op must not rewrite the file: a dirty re-render would drop
+      // the item's trailing separator blank for no reason.
+      if (!changed) return { task, already, changed };
+
       task.updated = this.now();
 
-      // Move the entry into the target section.
-      found.section.entries.splice(found.index, 1);
-      const moved: TaskEntry = { kind: "task", task, raw: [], dirty: true };
-      // Done and started work surface at the top; reopened work appends to queued.
-      this.insert(this.section(doc, to), moved, to !== "queued");
+      if (already) {
+        // Backfill in place; re-sorting a task within its own section would
+        // reorder the backlog on what is only a metadata write.
+        found.entry.dirty = true;
+      } else {
+        // Move the entry into the target section.
+        found.section.entries.splice(found.index, 1);
+        const moved: TaskEntry = { kind: "task", task, raw: [], dirty: true };
+        // Done and started work surface at the top; reopened work appends to queued.
+        this.insert(this.section(doc, to), moved, to !== "queued");
+      }
 
       this.persist(loaded);
-      return task;
+      return { task, already, changed };
     });
   }
 

--- a/src/backends/markdown.ts
+++ b/src/backends/markdown.ts
@@ -967,15 +967,6 @@ export class MarkdownStore implements Store {
       if (!found) throw new AxiError(`Task "${id}" not found`, "NOT_FOUND");
 
       const task = found.entry.task;
-      if (isPublicFollowupTask(task)) {
-        throw new AxiError(
-          "Public-followup state cannot change through generic transitions",
-          "VALIDATION_ERROR",
-          [
-            "Use `tasks-axi public-followup record-delivery` or `tasks-axi public-followup waive`",
-          ],
-        );
-      }
       const date = normalizeDate(opts.date ?? this.now(), "transition date");
 
       // The already/fresh decision is made HERE, on the freshly reread task
@@ -1018,6 +1009,20 @@ export class MarkdownStore implements Store {
           task.closed = undefined;
         }
         changed = true;
+      }
+
+      // A generic transition may never move or rewrite an obligation - only a
+      // posted receipt or a Captain waiver does. The guard keys off whether
+      // this call would actually mutate, so a pure no-op stays the idempotent
+      // success it is for every other verb.
+      if (changed && isPublicFollowupTask(task)) {
+        throw new AxiError(
+          "Public-followup state cannot change through generic transitions",
+          "VALIDATION_ERROR",
+          [
+            "Use `tasks-axi public-followup record-delivery` or `tasks-axi public-followup waive`",
+          ],
+        );
       }
 
       // A pure no-op must not rewrite the file: a dirty re-render would drop

--- a/src/commands/state.ts
+++ b/src/commands/state.ts
@@ -26,17 +26,17 @@ import type {
   Dep,
   Hold,
   HoldKind,
+  State,
   Task,
   TaskInput,
-  TaskLink,
-  TaskPatch,
+  TransitionOpts,
 } from "../model.js";
 import { HOLD_KINDS } from "../model.js";
 import {
   PUBLIC_FOLLOWUP_KIND,
   clonePublicFollowup,
 } from "../public-followup.js";
-import type { Store } from "../store.js";
+import type { Store, TransitionResult } from "../store.js";
 import { getSuggestions } from "../suggestions.js";
 import { renderHelp, renderOutput } from "../toon.js";
 import { renderTaskDetail, renderTaskList, showFullTextHint } from "../view.js";
@@ -123,11 +123,13 @@ export async function startCommand(
   const positionals = requirePositionals(args, 1, 1, START_HELP.split("\n")[0]);
   const id = requireId(positionals[0], "id");
 
-  const current = await store.get(id);
-  if (!current) throw notFound(id, { globals: context?.suggestionGlobals });
-
-  const already = current.state === "in_flight";
-  const task = already ? current : await store.transition(id, "in_flight");
+  const { task, already } = await transitionOrNotFound(
+    store,
+    id,
+    "in_flight",
+    {},
+    context,
+  );
   const all = (await store.list({})).items;
   return renderMutation({
     json,
@@ -170,62 +172,39 @@ export async function doneCommand(
   const id = requireId(positionals[0], "id");
   const keep = parseNonNegativeIntegerFlag("--keep", keepRaw, config.doneKeep);
 
-  const current = await store.get(id);
-  if (!current) throw notFound(id, { globals: context?.suggestionGlobals });
-
   const opts: { pr?: string; report?: string; note?: string } = {};
   if (pr !== undefined) opts.pr = pr;
   if (report !== undefined) opts.report = report;
   if (note !== undefined) opts.note = note;
 
-  if (current.state === "done") {
-    const patch = doneMetadataPatch(pr, report, note);
-    const hasPatch = Object.keys(patch).length > 0;
-    let task = current;
-    let changed = false;
-    if (hasPatch) {
-      const result = await store.update(id, patch);
-      task = result.task;
-      changed = result.changed.length > 0;
-    }
-    const pruned = await pruneDone(store, keep, noPrune);
-    const all = (await store.list({})).items;
-    return renderMutation({
-      json,
-      confirm: `done ${id} already -> ${stateLabel(task.state)}${doneExtras(pr, report)}${prunedNote(pruned)}`,
-      already: true,
-      jsonPayload: {
-        ok: true,
-        action: "done",
-        already: true,
-        pruned,
-        task: taskToJson(task, all),
-      },
-      ...(changed
-        ? { detail: renderTaskDetail(task, all, false, showFullTextHint(task)) }
-        : {}),
-      suggestions: getSuggestions({
-        action: "done",
-        id,
-        state: task.state,
-        globals: context?.suggestionGlobals,
-      }),
-    });
-  }
-
-  const task = await store.transition(id, "done", opts);
+  // One locked call decides already-vs-fresh and backfills metadata, so two
+  // concurrent closers can never both report that they performed the close.
+  const { task, already, changed } = await transitionOrNotFound(
+    store,
+    id,
+    "done",
+    opts,
+    context,
+  );
   const pruned = await pruneDone(store, keep, noPrune);
   const all = (await store.list({})).items;
 
   return renderMutation({
     json,
-    confirm: `done ${id} -> ${stateLabel(task.state)}${doneExtras(pr, report)}${prunedNote(pruned)}`,
+    confirm: already
+      ? `done ${id} already -> ${stateLabel(task.state)}${doneExtras(pr, report)}${prunedNote(pruned)}`
+      : `done ${id} -> ${stateLabel(task.state)}${doneExtras(pr, report)}${prunedNote(pruned)}`,
+    ...(already ? { already: true } : {}),
     jsonPayload: {
       ok: true,
       action: "done",
+      ...(already ? { already: true } : {}),
       pruned,
       task: taskToJson(task, all),
     },
+    ...(already && changed
+      ? { detail: renderTaskDetail(task, all, false, showFullTextHint(task)) }
+      : {}),
     suggestions: getSuggestions({
       action: "done",
       id,
@@ -233,6 +212,27 @@ export async function doneCommand(
       globals: context?.suggestionGlobals,
     }),
   });
+}
+
+/**
+ * `transition`, with the NOT_FOUND error enriched with id suggestions. The
+ * store owns the state decision (it holds the lock); the command only renders.
+ */
+async function transitionOrNotFound(
+  store: TasksContext["store"],
+  id: string,
+  to: State,
+  opts: TransitionOpts,
+  context: TasksContext | undefined,
+): Promise<TransitionResult> {
+  try {
+    return await store.transition(id, to, opts);
+  } catch (error) {
+    if (error instanceof AxiError && error.code === "NOT_FOUND") {
+      throw notFound(id, { globals: context?.suggestionGlobals });
+    }
+    throw error;
+  }
 }
 
 /** The `(pr X, report Y)` parenthetical for a done confirmation, omitted when bare. */
@@ -265,20 +265,6 @@ async function pruneDone(
   return result.archived;
 }
 
-function doneMetadataPatch(
-  pr: string | undefined,
-  report: string | undefined,
-  note: string | undefined,
-): TaskPatch {
-  const patch: TaskPatch = {};
-  const addLinks: TaskLink[] = [];
-  if (pr !== undefined) addLinks.push({ kind: "pr", url: pr });
-  if (report !== undefined) addLinks.push({ kind: "report", url: report });
-  if (addLinks.length > 0) patch.addLinks = addLinks;
-  if (note !== undefined) patch.addBodyLines = [note];
-  return patch;
-}
-
 export async function reopenCommand(
   rawArgs: string[],
   context?: TasksContext,
@@ -294,11 +280,13 @@ export async function reopenCommand(
   );
   const id = requireId(positionals[0], "id");
 
-  const current = await store.get(id);
-  if (!current) throw notFound(id, { globals: context?.suggestionGlobals });
-
-  const already = current.state === "queued";
-  const task = already ? current : await store.transition(id, "queued");
+  const { task, already } = await transitionOrNotFound(
+    store,
+    id,
+    "queued",
+    {},
+    context,
+  );
   const all = (await store.list({})).items;
   return renderMutation({
     json,

--- a/src/commands/state.ts
+++ b/src/commands/state.ts
@@ -191,9 +191,7 @@ export async function doneCommand(
 
   return renderMutation({
     json,
-    confirm: already
-      ? `done ${id} already -> ${stateLabel(task.state)}${doneExtras(pr, report)}${prunedNote(pruned)}`
-      : `done ${id} -> ${stateLabel(task.state)}${doneExtras(pr, report)}${prunedNote(pruned)}`,
+    confirm: `done ${id}${already ? " already" : ""} -> ${stateLabel(task.state)}${doneExtras(pr, report)}${prunedNote(pruned)}`,
     ...(already ? { already: true } : {}),
     jsonPayload: {
       ok: true,

--- a/src/store.ts
+++ b/src/store.ts
@@ -31,6 +31,19 @@ export interface Capabilities {
   publicFollowups: boolean;
 }
 
+/**
+ * The outcome of a state transition. The `already` decision is made inside the
+ * backend's critical section on a freshly reread task, never on a caller's
+ * pre-lock read, so concurrent callers cannot both claim they performed it.
+ */
+export interface TransitionResult {
+  task: Task;
+  /** True when the task was already in the target state on the locked reread. */
+  already: boolean;
+  /** True when this call actually wrote something. */
+  changed: boolean;
+}
+
 export interface PruneOptions {
   state: State;
   keep: number;
@@ -67,7 +80,11 @@ export interface Store {
   list(query: TaskQuery): Promise<{ items: Task[]; total: number }>;
 
   // state + dependencies
-  transition(id: string, to: State, opts?: TransitionOpts): Promise<Task>;
+  transition(
+    id: string,
+    to: State,
+    opts?: TransitionOpts,
+  ): Promise<TransitionResult>;
   addDep(id: string, dep: Dep): Promise<boolean>;
   removeDep(id: string, dep: Dep): Promise<boolean>;
 

--- a/test/backends/markdown.test.ts
+++ b/test/backends/markdown.test.ts
@@ -655,7 +655,7 @@ describe("MarkdownStore", () => {
     it("moves queued -> in_flight and stamps since", async () => {
       const b = makeBacklog();
       try {
-        const task = await b.store.transition("cert-cleanup", "in_flight");
+        const { task } = await b.store.transition("cert-cleanup", "in_flight");
         expect(task.state).toBe("in_flight");
         const read = b.read();
         // In-flight renders in firstmate's `- [ ]` checkbox form (same bullet as
@@ -669,7 +669,7 @@ describe("MarkdownStore", () => {
     it("carries a multi-paragraph body through start (queued -> in_flight)", async () => {
       const b = makeBacklog(multiParaQueued);
       try {
-        const task = await b.store.transition("multi-para", "in_flight");
+        const { task } = await b.store.transition("multi-para", "in_flight");
         expect(task.body).toContain("Second paragraph after a blank.");
         expect(task.body).toContain("## Intent");
         expect(task.body).toContain("final line");
@@ -717,7 +717,7 @@ describe("MarkdownStore", () => {
       ].join("\n");
       const b = makeBacklog(seeded);
       try {
-        const task = await b.store.transition("multi-para", "done", {
+        const { task } = await b.store.transition("multi-para", "done", {
           note: "closed note",
         });
         expect(task.body).toContain("Second paragraph after a blank.");
@@ -744,7 +744,7 @@ describe("MarkdownStore", () => {
     it("moves to done, records the pr link and a merged stamp", async () => {
       const b = makeBacklog();
       try {
-        const task = await b.store.transition("cert-cleanup", "done", {
+        const { task } = await b.store.transition("cert-cleanup", "done", {
           pr: "https://github.com/o/r/pull/7",
         });
         expect(task.state).toBe("done");
@@ -762,7 +762,7 @@ describe("MarkdownStore", () => {
         "# Backlog\n\n## Queued\n- [ ] task-q1 - title https://github.com/o/r/pull/10\n\n## Done\n",
       );
       try {
-        const task = await b.store.transition("task-q1", "done", {
+        const { task } = await b.store.transition("task-q1", "done", {
           pr: "https://github.com/o/r/pull/1",
         });
         expect(task.links).toContainEqual({

--- a/test/commands/public-followup.test.ts
+++ b/test/commands/public-followup.test.ts
@@ -599,6 +599,65 @@ describe("public-followup commands", () => {
     }
   });
 
+  it("stays idempotent for a generic transition that is a pure no-op", async () => {
+    const b = makeBacklog(EMPTY);
+    try {
+      await makeReady(b);
+      const queuedSource = b.read();
+
+      // An active obligation is already queued, so `reopen` changes nothing.
+      const reopened = await reopenCommand(["public-final-ab"], b.ctx);
+      expect(reopened).toContain("ok: reopen public-final-ab already queued");
+      expect(reopened).toContain("already: true");
+      expect(b.read()).toBe(queuedSource);
+
+      // ...but any transition that would genuinely move it still fails closed.
+      await expect(
+        doneCommand(["public-final-ab", "--no-prune"], b.ctx),
+      ).rejects.toMatchObject({ code: "VALIDATION_ERROR" });
+      await expect(
+        startCommand(["public-final-ab"], b.ctx),
+      ).rejects.toMatchObject({ code: "VALIDATION_ERROR" });
+      expect(b.read()).toBe(queuedSource);
+
+      await begin(b);
+      await run(b, "record-delivery", [
+        "public-final-ab",
+        "--receipt-file",
+        jsonFile(b, "receipt.json", receipt()),
+        "--json",
+      ]);
+      const completed = await b.store.get("public-final-ab");
+      expect(completed?.state).toBe("done");
+      const doneSource = b.read();
+
+      const closed = await doneCommand(
+        ["public-final-ab", "--no-prune"],
+        b.ctx,
+      );
+      expect(closed).toContain("ok: done public-final-ab already -> Done");
+      expect(closed).toContain("already: true");
+      expect(b.read()).toBe(doneSource);
+      expect(await b.store.get("public-final-ab")).toEqual(completed);
+
+      // Backfilling metadata is a real content change, so it stays refused.
+      await expect(
+        doneCommand(
+          [
+            "public-final-ab",
+            "--no-prune",
+            "--pr",
+            "https://github.com/o/r/pull/777",
+          ],
+          b.ctx,
+        ),
+      ).rejects.toMatchObject({ code: "VALIDATION_ERROR" });
+      expect(b.read()).toBe(doneSource);
+    } finally {
+      b.cleanup();
+    }
+  });
+
   it("keeps same-backlog operational blockers as delivery gates", async () => {
     const b = makeBacklog(EMPTY);
     try {

--- a/test/commands/state.test.ts
+++ b/test/commands/state.test.ts
@@ -358,11 +358,13 @@ describe("state commands", () => {
     it("preserves body edits made before an already-done note update", async () => {
       const b = makeBacklog();
       try {
-        const originalUpdate = b.store.update.bind(
+        // The already-done note backfill runs inside `transition` (the call
+        // that holds the lock), so the concurrent hand-edit is injected there.
+        const originalTransition = b.store.transition.bind(
           b.store,
-        ) as typeof b.store.update;
+        ) as typeof b.store.transition;
         let injected = false;
-        b.store.update = async (taskId, patch) => {
+        b.store.transition = async (taskId, to, opts) => {
           if (!injected) {
             injected = true;
             writeFileSync(
@@ -376,7 +378,7 @@ describe("state commands", () => {
               "utf8",
             );
           }
-          return originalUpdate(taskId, patch);
+          return originalTransition(taskId, to, opts);
         };
 
         await doneCommand(
@@ -392,6 +394,44 @@ describe("state commands", () => {
         const read = b.read();
         expect(read).toContain("concurrent audit note");
         expect(read).toContain("backfilled review evidence");
+      } finally {
+        b.cleanup();
+      }
+    });
+
+    it("lets exactly one of two concurrent closers claim the transition", async () => {
+      // Regression for the TOCTOU in issue #31: the already/fresh decision must
+      // be made inside the transition lock, not on a caller's pre-lock read.
+      // Deciding it before the lock let BOTH callers report a fresh close.
+      const b = makeBacklog();
+      try {
+        const outputs = await Promise.all([
+          doneCommand(
+            [
+              "cert-cleanup",
+              "--pr",
+              "https://github.com/o/r/pull/101",
+              "--json",
+              "--no-prune",
+            ],
+            b.ctx,
+          ),
+          doneCommand(
+            [
+              "cert-cleanup",
+              "--pr",
+              "https://github.com/o/r/pull/202",
+              "--json",
+              "--no-prune",
+            ],
+            b.ctx,
+          ),
+        ]);
+        const results = outputs.map((out) => JSON.parse(out));
+        const claimed = results.filter((r) => r.already === undefined);
+        const observed = results.filter((r) => r.already === true);
+        expect(claimed).toHaveLength(1);
+        expect(observed).toHaveLength(1);
       } finally {
         b.cleanup();
       }


### PR DESCRIPTION
## Intent

The user is new to this repo and asked me to investigate open issue #31, then determine whether it is fixable. It was: this change fixes it.

GOAL: concurrent `done` calls on the same task both reported a successful fresh state transition. Neither returned `already: true`, and both PR links landed on the task, so a coordinator driving multiple agents against one backlog cannot tell which caller was the authoritative closer. That is semantic and audit corruption, not file corruption - the markdown stays valid throughout.

REPRODUCED FIRST, E2E: before writing any fix I reproduced it two ways - the reporter's deterministic in-process script, and (more importantly) two real concurrent OS processes invoking the CLI, which raced on the first attempt with no instrumentation. That is how multiple agents would actually hit it.

ROOT CAUSE: `MarkdownStore.transition` already reread the backlog inside `withLock`, but the already-vs-fresh decision was made earlier on an unlocked `store.get` in the command layer, then never rechecked under the lock. The lock serialized the writes, not the decision (TOCTOU). `start` and `reopen` shared the same unlocked-read-then-locked-write shape and lost the `already` signal to both callers; they are fixed by the same change.

DESIGN DECISION - I deliberately did NOT implement the reporter's suggested fix. They proposed compare-and-swap: caller passes the state it observed, store compares under the lock, returns applied:false on mismatch. That works but keeps the state decision in the caller and needs a retry loop at every call site. Instead I moved the decision to the side of the Store seam that owns the lock: `Store.transition` now returns `{ task, already, changed }` and computes `already` from the freshly reread task inside the critical section. Commands stopped deciding state entirely and only render the result. This let `doneCommand`'s two branches collapse into one call, so the command layer got shorter.

THIS CHANGES THE `Store` INTERFACE (transition's return type). That is intentional and I judged it acceptable: P1 ships one backend and there were only 3 `store.transition` call sites. It also means future sqlite/remote backends inherit the correct locked-decision contract rather than each reinventing it.

BEHAVIOUR I DELIBERATELY PRESERVED (these look like omissions in the diff but are choices):
- an already-done task keeps its ORIGINAL closed date and only backfills supplied --pr/--report/--note metadata, matching documented idempotent `done` behaviour
- a true no-op does NOT rewrite the file. This matters specifically because a dirty re-render drops an item's trailing separator blank line, so writing on a no-op would silently reflow the backlog. There is an existing test asserting byte-identical output on that path.
- the already-path marks the entry dirty IN PLACE rather than splice-and-reinsert, because reinserting would re-sort the task to the top of its own section on what is only a metadata write

TEST WORK: 6 tests failed initially. 5 were mechanical (they destructured transition's old return type). The 6th was substantive and worth a reviewer's attention: a test injects a concurrent hand-edit by wrapping `store.update`, which the already-done backfill no longer routes through. I re-pointed that hook at `store.transition` and confirmed it still passes for the right reason - both the injected note and the backfilled note land in the file - rather than passing because the hook silently stopped firing. I also removed `doneMetadataPatch`, now dead code, and its two now-unused type imports.

REGRESSION TEST: added one that drives two concurrent doneCommand calls with NO instrumentation and asserts exactly one claims the transition. I verified it FAILS against the original implementation (got 2 claimers, expected 1) and passes with the fix.

OPEN PRODUCT DECISION LEFT INTENTIONALLY UNRESOLVED: CAS/locked-decision fixes the false 'I closed it' claim but does not by itself forbid two PR links on one task. The second closer still backfills its PR, consistent with documented backfill behaviour. The reporter flagged that if 'one closing PR' is meant to be an invariant, a DIFFERING --pr on an already-done task should return a conflict instead of appending. That is a product call for the maintainer, so I left current behaviour intact rather than guess. Please do not flag the absence of that restriction as a defect.

Full local gate was green before pushing: pnpm build, pnpm lint, 430 tests passing, and build:skill --check reports no drift.

## What Changed

- `Store.transition` now returns `{ task, already, changed }` and `MarkdownStore.transition` derives `already` from the task it rereads inside `withLock`, so concurrent `done`/`start`/`reopen` callers can no longer both report a fresh transition. A pure no-op returns without writing (preserving byte-identical output), and an already-done task backfills supplied `--pr`/`--report`/`--note` in place - keeping its original closed date and its position in the Done section - instead of being spliced back to the top.
- `startCommand`/`doneCommand`/`reopenCommand` stopped deciding state from an unlocked `store.get` and now render whatever the store returns via a shared `transitionOrNotFound` helper that re-attaches id suggestions to `NOT_FOUND`; `doneCommand`'s separate already-done branch and the now-dead `doneMetadataPatch` were removed.
- The public-followup guard against generic transitions now keys off `changed`, so a no-op `reopen` on an active obligation stays an idempotent `already: true` success while any state, link, or note write still fails with `VALIDATION_ERROR`.
- Added a regression test driving two concurrent `doneCommand` calls and asserting exactly one claims the transition; re-pointed the concurrent hand-edit injection test from `store.update` to `store.transition`, updated the store tests for the new return shape, and documented the locked-decision contract in `AGENTS.md` and `README.md`.

## Risk Assessment

✅ Low: The TOCTOU fix moves the already/fresh decision inside the existing lock with no new locking or file-format surface, the re-narrowed public-followup guard provably still fails closed on every state-changing path, and both are covered by tests that fail against the pre-fix behavior; only two cosmetic/documentation nits remain.

## Testing

I reproduced issue #31 end-to-end before validating the fix by racing two real OS processes invoking `tasks-axi done --pr` against a single backlog file: on the base commit both processes reported a successful fresh close in all 8 attempts, and on the fixed commit exactly one claimed the transition while the other returned `already: true` in all 8. I also confirmed the author's new unit regression test genuinely fails against the original implementation, then exercised the preserved idempotency behaviours through the CLI (original closed date retained, metadata backfilled in place without re-sorting, pure no-ops leaving the file byte-identical, no duplicated PR links or notes) and the public-followup guard (real generic transitions still refused with exit 2, no-ops now idempotent). The targeted suites covering every `store.transition` call site pass; no findings, and the worktree was left clean with build output and scratch dirs removed. No visual evidence applies - this is a CLI-only change, so CLI transcripts are the end-user surface.

<details>
<summary>Evidence: Concurrent `done --pr` race: 8 iterations before vs after the fix</summary>

<code>8 back-to-back races, each a fresh backlog with one in-flight task and two&#10;real OS processes running: tasks-axi done &lt;id&gt; --pr &lt;distinct url&gt; --json&#10;&#10;### BEFORE FIX (base 48a5a90)&#10;iter 1 [BASE]: BOTH callers claimed a fresh close (no &#39;already&#39;)&#10;iter 2 [BASE]: BOTH callers claimed a fresh close (no &#39;already&#39;)&#10;iter 3 [BASE]: BOTH callers claimed a fresh close (no &#39;already&#39;)&#10;iter 4 [BASE]: BOTH callers claimed a fresh close (no &#39;already&#39;)&#10;iter 5 [BASE]: BOTH callers claimed a fresh close (no &#39;already&#39;)&#10;iter 6 [BASE]: BOTH callers claimed a fresh close (no &#39;already&#39;)&#10;iter 7 [BASE]: BOTH callers claimed a fresh close (no &#39;already&#39;)&#10;iter 8 [BASE]: BOTH callers claimed a fresh close (no &#39;already&#39;)&#10;=== [BASE] iterations where BOTH claimed the close: 8 / 8 ===&#10;&#10;### AFTER FIX (head 7914848)&#10;iter 1 [FIXED]: exactly one fresh closer, one reported already:true&#10;iter 2 [FIXED]: exactly one fresh closer, one reported already:true&#10;iter 3 [FIXED]: exactly one fresh closer, one reported already:true&#10;iter 4 [FIXED]: exactly one fresh closer, one reported already:true&#10;iter 5 [FIXED]: exactly one fresh closer, one reported already:true&#10;iter 6 [FIXED]: exactly one fresh closer, one reported already:true&#10;iter 7 [FIXED]: exactly one fresh closer, one reported already:true&#10;iter 8 [FIXED]: exactly one fresh closer, one reported already:true&#10;=== [FIXED] iterations where BOTH claimed the close: 0 / 8 ===</code>

```text
8 back-to-back races, each a fresh backlog with one in-flight task and two
real OS processes running: tasks-axi done <id> --pr <distinct url> --json

### BEFORE FIX (base 48a5a90)
iter 1 [BASE]: BOTH callers claimed a fresh close (no 'already')
iter 2 [BASE]: BOTH callers claimed a fresh close (no 'already')
iter 3 [BASE]: BOTH callers claimed a fresh close (no 'already')
iter 4 [BASE]: BOTH callers claimed a fresh close (no 'already')
iter 5 [BASE]: BOTH callers claimed a fresh close (no 'already')
iter 6 [BASE]: BOTH callers claimed a fresh close (no 'already')
iter 7 [BASE]: BOTH callers claimed a fresh close (no 'already')
iter 8 [BASE]: BOTH callers claimed a fresh close (no 'already')
=== [BASE] iterations where BOTH claimed the close: 8 / 8 ===

### AFTER FIX (head 7914848)
iter 1 [FIXED]: exactly one fresh closer, one reported already:true
iter 2 [FIXED]: exactly one fresh closer, one reported already:true
iter 3 [FIXED]: exactly one fresh closer, one reported already:true
iter 4 [FIXED]: exactly one fresh closer, one reported already:true
iter 5 [FIXED]: exactly one fresh closer, one reported already:true
iter 6 [FIXED]: exactly one fresh closer, one reported already:true
iter 7 [FIXED]: exactly one fresh closer, one reported already:true
iter 8 [FIXED]: exactly one fresh closer, one reported already:true
=== [FIXED] iterations where BOTH claimed the close: 0 / 8 ===
```
</details>
<details>
<summary>Evidence: Full before/after CLI transcript of one race, with both agents&#39; --json payloads and the resulting backlog.md</summary>

<code>--- BEFORE FIX: agent A (pull/101) stdout ---&#10;{&#10;&#34;ok&#34;: true,&#10;&#34;action&#34;: &#34;done&#34;,&#10;&#34;pruned&#34;: 0,&#10;&#34;task&#34;: { &#34;id&#34;: &#34;cert-cleanup&#34;, &#34;state&#34;: &#34;done&#34;, &#34;closed&#34;: &#34;2026-08-20&#34;, ... }&#10;}&#10;--- BEFORE FIX: agent B (pull/202) stdout ---&#10;{&#10;&#34;ok&#34;: true,&#10;&#34;action&#34;: &#34;done&#34;,&#10;&#34;pruned&#34;: 0,&#10;&#34;task&#34;: { &#34;id&#34;: &#34;cert-cleanup&#34;, &#34;state&#34;: &#34;done&#34;, &#34;closed&#34;: &#34;2026-08-20&#34;, ... }&#10;}&#10;&gt;&gt;&gt; VERDICT: BUG - both callers reported a fresh close; no caller is identifiable as the authoritative closer.&#10;&#10;--- AFTER FIX: agent A (pull/101) stdout ---&#10;{&#10;&#34;ok&#34;: true,&#10;&#34;action&#34;: &#34;done&#34;,&#10;&#34;pruned&#34;: 0,&#10;&#34;task&#34;: { &#34;id&#34;: &#34;cert-cleanup&#34;, &#34;state&#34;: &#34;done&#34;, ... }&#10;}&#10;--- AFTER FIX: agent B (pull/202) stdout ---&#10;{&#10;&#34;ok&#34;: true,&#10;&#34;action&#34;: &#34;done&#34;,&#10;&#34;already&#34;: true,&#10;&#34;pruned&#34;: 0,&#10;&#34;task&#34;: { &#34;id&#34;: &#34;cert-cleanup&#34;, &#34;state&#34;: &#34;done&#34;, ... }&#10;}&#10;&gt;&gt;&gt; VERDICT: OK - exactly one fresh closer; the loser reports already:true.</code>

```text
======================================================================
  BEFORE FIX  (base 48a5a90)  -  two concurrent OS processes
======================================================================
$ cat backlog.md
# Backlog

## In flight
- [ ] cert-cleanup - rotate the expiring service certs (repo: infra)

## Queued

## Done

$ tasks-axi done cert-cleanup --pr .../pull/101 --json --no-prune --file backlog.md  &   # agent A
$ tasks-axi done cert-cleanup --pr .../pull/202 --json --no-prune --file backlog.md  &   # agent B

--- agent A (pull/101) stdout ---
{
  "ok": true,
  "action": "done",
  "pruned": 0,
  "task": {
    "id": "cert-cleanup",
    "title": "rotate the expiring service certs https://github.com/o/r/pull/202 https://github.com/o/r/pull/101",
    "state": "done",
    "kind": null,
    "repo": "infra",
    "priority": null,
    "created": null,
    "closed": "2026-08-20",
    "deps": [],
    "hold": null,
    "links": [
      {
        "kind": "pr",
        "url": "https://github.com/o/r/pull/202"
      },
      {
        "kind": "pr",
        "url": "https://github.com/o/r/pull/101"
      }
    ],
    "body": null,
    "blocked": false,
    "blocked_by": [],
    "held": false
  }
}
--- agent B (pull/202) stdout ---
{
  "ok": true,
  "action": "done",
  "pruned": 0,
  "task": {
    "id": "cert-cleanup",
    "title": "rotate the expiring service certs https://github.com/o/r/pull/202",
    "state": "done",
    "kind": null,
    "repo": "infra",
    "priority": null,
    "created": null,
    "closed": "2026-08-20",
    "deps": [],
    "hold": null,
    "links": [
      {
        "kind": "pr",
        "url": "https://github.com/o/r/pull/202"
      }
    ],
    "body": null,
    "blocked": false,
    "blocked_by": [],
    "held": false
  }
}

--- resulting backlog.md ---
# Backlog

## In flight
## Queued

## Done
- [x] cert-cleanup - rotate the expiring service certs https://github.com/o/r/pull/202 https://github.com/o/r/pull/101 (repo: infra) (merged 2026-08-20)

>>> VERDICT: BUG - both callers reported a fresh close; no caller is identifiable as the authoritative closer.

======================================================================
  AFTER FIX   (head 7914848)  -  two concurrent OS processes
======================================================================
$ cat backlog.md
# Backlog

## In flight
- [ ] cert-cleanup - rotate the expiring service certs (repo: infra)

## Queued

## Done

$ tasks-axi done cert-cleanup --pr .../pull/101 --json --no-prune --file backlog.md  &   # agent A
$ tasks-axi done cert-cleanup --pr .../pull/202 --json --no-prune --file backlog.md  &   # agent B

--- agent A (pull/101) stdout ---
{
  "ok": true,
  "action": "done",
  "pruned": 0,
  "task": {
    "id": "cert-cleanup",
    "title": "rotate the expiring service certs https://github.com/o/r/pull/101",
    "state": "done",
    "kind": null,
    "repo": "infra",
    "priority": null,
    "created": null,
    "closed": "2026-08-20",
    "deps": [],
    "hold": null,
    "links": [
      {
        "kind": "pr",
        "url": "https://github.com/o/r/pull/101"
      }
    ],
    "body": null,
    "blocked": false,
    "blocked_by": [],
    "held": false
  }
}
--- agent B (pull/202) stdout ---
{
  "ok": true,
  "action": "done",
  "already": true,
  "pruned": 0,
  "task": {
    "id": "cert-cleanup",
    "title": "rotate the expiring service certs https://github.com/o/r/pull/101 https://github.com/o/r/pull/202",
    "state": "done",
    "kind": null,
    "repo": "infra",
    "priority": null,
    "created": null,
    "closed": "2026-08-20",
    "deps": [],
    "hold": null,
    "links": [
      {
        "kind": "pr",
        "url": "https://github.com/o/r/pull/101"
      },
      {
        "kind": "pr",
        "url": "https://github.com/o/r/pull/202"
      }
    ],
    "body": null,
    "blocked": false,
    "blocked_by": [],
    "held": false
  }
}

--- resulting backlog.md ---
# Backlog

## In flight
## Queued

## Done
- [x] cert-cleanup - rotate the expiring service certs https://github.com/o/r/pull/101 https://github.com/o/r/pull/202 (repo: infra) (merged 2026-08-20)

>>> VERDICT: OK - exactly one fresh closer; the loser reports already:true.
```
</details>
<details>
<summary>Evidence: Idempotency + no-op CLI transcript (original closed date kept, no re-sort, byte-identical file on no-ops)</summary>

<code>$ tasks-axi done cert-cleanup --pr https://github.com/o/r/pull/202 --no-prune&#10;ok: done cert-cleanup already -&gt; Done (pr https://github.com/o/r/pull/202)&#10;already: true&#10;closed: 2026-08-01 &lt;- ORIGINAL stamp preserved&#10;links: &#34;pr:.../pull/101,pr:.../pull/202&#34;&#10;&#10;## Done&#10;- [x] newer-thing - shipped later (repo: infra) (merged 2026-08-10)&#10;- [x] cert-cleanup - rotate the expiring service certs .../pull/101 .../pull/202 (repo: infra) (merged 2026-08-01)&#10;^ still below newer-thing: not re-sorted&#10;&#10;$ tasks-axi done cert-cleanup --no-prune # already Done, nothing to backfill&#10;ok: done cert-cleanup already -&gt; Done&#10;already: true&#10;$ tasks-axi start other # already In flight&#10;ok: start other already in flight&#10;already: true&#10;$ tasks-axi reopen db-index # already Queued&#10;ok: reopen db-index already queued&#10;already: true&#10;&#10;$ diff before.md backlog.md&#10;(identical - three no-op transitions wrote nothing)&#10;&#10;$ tasks-axi done cert-cleanup --no-prune --json | grep already&#10;&#34;already&#34;: true,&#10;$ tasks-axi start other --json | grep already&#10;&#34;already&#34;: true,&#10;$ tasks-axi reopen db-index --json | grep already&#10;&#34;already&#34;: true,</code>

```text
== seed backlog.md (cert-cleanup was closed on 2026-08-01, sitting BELOW newer-thing) ==
# Backlog

## In flight
- [ ] other - unrelated work (repo: infra)

## Queued
- [ ] db-index - add the missing index (repo: infra)

## Done
- [x] newer-thing - shipped later (repo: infra) (merged 2026-08-10)
- [x] cert-cleanup - rotate the expiring service certs https://github.com/o/r/pull/101 (repo: infra) (merged 2026-08-01)

== 1. a later closer retries with its own PR: reports 'already', keeps the ORIGINAL 2026-08-01 stamp, does not re-sort ==
$ tasks-axi done cert-cleanup --pr https://github.com/o/r/pull/202 --no-prune
ok: done cert-cleanup already -> Done (pr https://github.com/o/r/pull/202)
already: true
task:
  id: cert-cleanup
  title: "rotate the expiring service certs https://github.com/o/r/pull/101 https://github\n... (truncated, 97 chars total - use show cert-cleanup --full to see complete text)"
  state: done
  blocked: no
  blocked_by: none
  held: no
  hold_reason: "-"
  hold_kind: "-"
  hold_until: "-"
  kind: task
  repo: infra
  priority: "-"
  created: "-"
  closed: 2026-08-01
  deps: none
  links: "pr:https://github.com/o/r/pull/101,pr:https://github.com/o/r/pull/202"
  body: ""
help[1]:
  - Run `tasks-axi ready --file=/tmp/toctou/seq/backlog.md` to dispatch work unblocked by this

$ cat backlog.md
# Backlog

## In flight
- [ ] other - unrelated work (repo: infra)

## Queued
- [ ] db-index - add the missing index (repo: infra)

## Done
- [x] newer-thing - shipped later (repo: infra) (merged 2026-08-10)
- [x] cert-cleanup - rotate the expiring service certs https://github.com/o/r/pull/101 https://github.com/o/r/pull/202 (repo: infra) (merged 2026-08-01)

== 2. pure no-op transitions must not rewrite the file at all ==
$ tasks-axi done cert-cleanup --no-prune   # already Done, nothing to backfill
ok: done cert-cleanup already -> Done
already: true
help[1]:
  - Run `tasks-axi ready --file=/tmp/toctou/seq/backlog.md` to dispatch work unblocked by this
$ tasks-axi start other                    # already In flight
ok: start other already in flight
already: true
help[1]:
  - Run `tasks-axi done other --pr <url> --file=/tmp/toctou/seq/backlog.md` when it ships
$ tasks-axi reopen db-index                # already Queued
ok: reopen db-index already queued
already: true
help[1]:
  - Run `tasks-axi start db-index --file=/tmp/toctou/seq/backlog.md` to move it to in flight

$ diff before.md backlog.md   # blank separator lines and item order must survive
(identical - three no-op transitions wrote nothing)

== 3. every no-op still tells a machine caller it was NOT the actor ==
$ tasks-axi done cert-cleanup --no-prune --json | grep already
  "already": true,
$ tasks-axi start other --json | grep already
  "already": true,
$ tasks-axi reopen db-index --json | grep already
  "already": true,

$ diff before.md backlog.md   # still untouched after the --json no-ops
(identical)
```
</details>
<details>
<summary>Evidence: public-followup guard CLI transcript (real transitions still refused, no-ops idempotent)</summary>

<code>$ tasks-axi list --fields delivery_state&#10;public-final-ab,queued,public-followup,&#34;-&#34;,Follow up when the public-safe fix ships,ready&#10;&#10;$ tasks-axi reopen public-final-ab # already Queued -&gt; pure no-op, idempotent&#10;ok: reopen public-final-ab already queued&#10;already: true&#10;exit=0&#10;&#10;$ tasks-axi done public-final-ab --no-prune # would really move it -&gt; refused&#10;error: Public-followup state cannot change through generic transitions&#10;code: VALIDATION_ERROR&#10;exit=2&#10;&#10;$ tasks-axi start public-final-ab # would really move it -&gt; refused&#10;error: Public-followup state cannot change through generic transitions&#10;code: VALIDATION_ERROR&#10;exit=2&#10;&#10;$ diff before.md backlog.md&#10;(identical - the obligation was never moved or rewritten)&#10;&#10;== after a real posted receipt completes it ==&#10;$ tasks-axi done public-final-ab --no-prune&#10;ok: done public-final-ab already -&gt; Done&#10;already: true&#10;exit=0&#10;&#10;$ tasks-axi done public-final-ab --pr https://github.com/o/r/pull/777 --no-prune&#10;error: Public-followup state cannot change through generic transitions&#10;exit=2&#10;&#10;$ diff after-delivery.md backlog.md&#10;(identical)</code>

```text
== an active public-followup obligation: generic verbs must never move it, but a no-op stays idempotent ==
$ tasks-axi list --fields delivery_state
count: 2
tasks[2]{id,state,kind,repo,title,delivery_state}:
  ordinary-q1,queued,task,"-",ordinary work,"-"
  public-final-ab,queued,public-followup,"-",Follow up when the public-safe fix ships,ready
help[2]:
  - Run `tasks-axi show <id> --file=/tmp/toctou/pf/backlog.md` for full notes on a task
  - Run `tasks-axi ready --file=/tmp/toctou/pf/backlog.md` to see unblocked queued work

$ tasks-axi reopen public-final-ab      # already Queued -> pure no-op, idempotent
ok: reopen public-final-ab already queued
already: true
help[1]:
  - Run `tasks-axi start public-final-ab --file=/tmp/toctou/pf/backlog.md` to move it to in flight
exit=0

$ tasks-axi done public-final-ab --no-prune   # would really move it -> refused
error: Public-followup state cannot change through generic transitions
code: VALIDATION_ERROR
help[1]: Use `tasks-axi public-followup record-delivery` or `tasks-axi public-followup waive`
exit=2

$ tasks-axi start public-final-ab             # would really move it -> refused
error: Public-followup state cannot change through generic transitions
code: VALIDATION_ERROR
help[1]: Use `tasks-axi public-followup record-delivery` or `tasks-axi public-followup waive`
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"0710bdcb3594e239b4f6bb5e21c7a256ea094015","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 2 infos</summary>

- ⚠️ `src/commands/state.ts:182` - `done`/`reopen` on a public-followup obligation that was previously an idempotent success now hard-errors. `MarkdownStore.transition` (src/backends/markdown.ts:970) rejects ANY task with `kind=public-followup`, terminal or not. Before this change those calls never reached the store: `doneCommand`&#39;s already-branch built an empty `doneMetadataPatch` and skipped `store.update`, and `reopenCommand` short-circuited on `already = current.state === &#34;queued&#34;`. Now both always call `transition`. Concrete path: after `public-followup record-delivery` completes an obligation (state `done`, kind `public-followup` - see test/commands/public-followup.test.ts:667), `tasks-axi done public-final-ab --no-prune` used to print `ok: done public-final-ab already -&gt; Done` + `already: true` at exit 0; it now throws VALIDATION_ERROR (&#34;Public-followup state cannot change through generic transitions&#34;) at exit 2. Same for `tasks-axi reopen &lt;queued-obligation-id&gt;`. This is stricter than the documented invariant, which guards *active* obligations (`remove` at src/backends/markdown.ts:791 explicitly permits terminal ones), and no test covers the terminal case so the suite stayed green. It is a defensible hardening, but it narrows a documented idempotent contract (`DONE_HELP`: &#34;Re-running on an already Done task backfills links/notes without changing the close date&#34;) and is not listed among the intent&#39;s deliberately-preserved behaviors - a coordinator batch-closing ids that include a completed obligation now gets a non-zero exit instead of `already: true`. Decide whether `transition` should pass through when `already &amp;&amp; isPublicFollowupTerminal(...)` (or when nothing would change), or whether the new hard error is the intended contract.
- ℹ️ `src/commands/state.ts:485` - Informational, pre-existing and outside this change&#39;s stated scope: `holdCommand` (line 485) and `unholdCommand` (line 537) still decide `already` from an unlocked `store.get` and then write via `store.update`, the exact shape this change removed from the transition verbs. Two concurrent `tasks-axi hold X --reason &#34;r&#34;` calls therefore both print `ok: hold X -&gt; held` with no `already` marker, the same false-claim/audit class as issue #31 (though not a state transition). `store.update` already returns its `changed` array computed inside the lock, so the same locked-decision pattern would apply directly if the maintainer wants to extend the fix. Not introduced by this diff and not a merge concern.
- ℹ️ `src/commands/state.ts:194` - The `confirm` ternary duplicates the entire confirmation template just to insert the word `already`. `confirm: `done ${id}${already ? &#34; already&#34; : &#34;&#34;} -&gt; ${stateLabel(task.state)}${doneExtras(pr, report)}${prunedNote(pruned)}`` produces byte-identical output for both branches and removes the risk of the two copies drifting when the suffix helpers change.

🔧 Fix: allow no-op generic transitions on public-followup obligations
2 infos still open:
- ℹ️ `src/commands/state.ts:196` - `doneCommand` passes the `already` signal to `renderMutation` as `...(already ? { already: true } : {})`, while the sibling `startCommand` (line 137) and `reopenCommand` (line 293) pass the boolean directly as `already,`. `MutationOutput.already` is optional and `renderMutation` only tests truthiness (`if (output.already)` in src/confirm.ts:68), so the spread is byte-identical to `already,` and just adds a second spelling of the same thing in newly-changed code. The conditional spread is genuinely needed for the `jsonPayload` object a few lines below (there the key must be absent, not `false`, since the regression test distinguishes claimers via `r.already === undefined`), which is likely why it was copied up. Collapsing the outer one to `already,` matches the two siblings and removes the invitation to &#34;fix&#34; the jsonPayload spread the same way.
- ℹ️ `src/backends/markdown.ts:1018` - The public-followup invariant in AGENTS.md still reads as a blanket rule (&#34;Generic worker readiness and lifecycle transitions cannot dispatch, complete, reopen, remove, or change the kind of an active obligation&#34;), but the guard is now keyed off `changed`, so a generic transition that is a pure no-op on an obligation is an idempotent success (exit 0, `already: true`) rather than an error. That nuance is exactly what the blanket reading got wrong once already in this branch, and AGENTS.md explicitly directs future sqlite/remote backend authors to inherit this contract - a backend implemented from the doc alone would reimplement the over-broad guard and break `reopen` on a queued obligation and `done` on a completed one. One clause on that line (&#34;a transition that would change nothing stays an idempotent success&#34;) closes the gap; the `TransitionResult` docstring in src/store.ts:34 already covers the locked-decision half of the contract.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Built base commit `48a5a90` into a scratch dir and raced two real OS processes: `tasks-axi done cert-cleanup --pr .../pull/101 --json --no-prune &amp;` + `tasks-axi done cert-cleanup --pr .../pull/202 --json --no-prune &amp;` — bug reproduced 8/8 iterations (both callers claimed a fresh close)</code>
- <code>Repeated the same two-process race against head `7914848` — 0/8 iterations double-claimed; exactly one fresh closer and one `already: true` every time</code>
- <code>Copied the new `test/commands/state.test.ts` onto the base source and ran `vitest run test/commands/state.test.ts -t &#34;lets exactly one of two concurrent closers claim the transition&#34;` — FAILS on base with `expected [ …(2) ] to have a length of 1 but got 2`</code>
- <code>`vitest run test/commands/state.test.ts test/commands/public-followup.test.ts test/backends/markdown.test.ts` on head — 169 passed</code>
- <code>`vitest run test/commands/crud.test.ts` (the remaining `store.transition` call site) — passed</code>
- <code>Manual CLI: seeded a backlog with `cert-cleanup` closed `(merged 2026-08-01)` below a newer Done item, then `tasks-axi done cert-cleanup --pr .../pull/202 --no-prune` — reports `already`, keeps the 2026-08-01 stamp, backfills the PR, does not re-sort the item</code>
- <code>Manual CLI: `done`/`start`/`reopen` no-ops on already-in-target-state tasks, then `diff before.md backlog.md` — byte-identical, blank separators and ordering intact, while all three still return `&#34;already&#34;: true` under `--json`</code>
- <code>Manual CLI: identical-args retry `done a1 --pr .../pull/9 --note &#34;shipped&#34;` — no duplicated PR link, no duplicated note, no file rewrite</code>
- <code>Manual CLI: built a real public-followup obligation via `public-followup add`/`bind-work`/`work-event`, then `reopen` (idempotent no-op, exit 0), `done` and `start` (refused, VALIDATION_ERROR exit 2, file untouched); after `begin-delivery` + `record-delivery`, `done` is a plain no-op while `done --pr .../pull/777` is still refused</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
