### PR TITLE
ci: require no-mistakes pipeline attestation in the gate

### DIFF
--- a/.github/workflows/no-mistakes-required.yml
+++ b/.github/workflows/no-mistakes-required.yml
@@ -34,7 +34,7 @@ jobs:
       github.event.pull_request.user.login != 'dependabot[bot]' &&
       github.event.pull_request.user.login != 'release-please[bot]'
     steps:
-      - name: Verify no-mistakes signature in PR body
+      - name: Verify no-mistakes signature and pipeline attestation in PR body
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
@@ -44,19 +44,179 @@ jobs:
           marker='Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)'
           if printf '%s' "${PR_BODY:-}" | grep -qF -- "$marker"; then
             echo "Found no-mistakes signature in PR #${PR_NUMBER} body."
-            exit 0
+          else
+            {
+              echo "::error::This PR was not raised through no-mistakes."
+              echo
+              echo "Contributions to this repository must be submitted via 'git push no-mistakes'."
+              echo "That pipeline runs the required review/test/lint/CI steps and writes a"
+              echo "deterministic '## Pipeline' section into the PR body containing:"
+              echo
+              echo "    $marker"
+              echo
+              echo "See CONTRIBUTING.md for setup and the full workflow."
+              echo
+              echo "PR author: ${PR_AUTHOR}"
+            } >&2
+            exit 1
           fi
-          {
-            echo "::error::This PR was not raised through no-mistakes."
-            echo
-            echo "Contributions to this repository must be submitted via 'git push no-mistakes'."
-            echo "That pipeline runs the required review/test/lint/CI steps and writes a"
-            echo "deterministic '## Pipeline' section into the PR body containing:"
-            echo
-            echo "    $marker"
-            echo
-            echo "See CONTRIBUTING.md for setup and the full workflow."
-            echo
-            echo "PR author: ${PR_AUTHOR}"
-          } >&2
-          exit 1
+
+          # The signature alone only proves the pipeline wrote the body. no-mistakes
+          # >= 1.46.0 also emits a machine-readable step attestation next to it; parse
+          # that to prove review, test, and document actually ran to completion.
+          # Contract: docs/reference/pipeline-steps.md#pipeline-step-attestation in
+          # kunchenguid/no-mistakes.
+          attestation_prefix='<!-- no-mistakes-pipeline-attestation:v1 '
+          attestation_suffix=' -->'
+
+          if ! printf '%s' "${PR_BODY:-}" | grep -qF -- "$attestation_prefix"; then
+            echo "::error::This PR carries the no-mistakes signature but no pipeline attestation."
+            {
+              echo
+              echo "no-mistakes >= 1.46.0 is required (PR 670). That release writes a"
+              echo "machine-readable comment next to the signature:"
+              echo
+              echo "    ${attestation_prefix}{\"head_sha\":\"...\",\"steps\":[...]}${attestation_suffix}"
+              echo
+              echo "Upgrade no-mistakes ('no-mistakes update'), then re-run"
+              echo "'git push no-mistakes' so the PR body is rewritten with the attestation."
+              echo
+              echo "PR author: ${PR_AUTHOR}"
+            } >&2
+            exit 1
+          fi
+
+          # Exact-substring extraction (no regex): first prefix, then the first
+          # closing token after it, mirroring how no-mistakes' own consumer test
+          # slices the payload.
+          payload="$(
+            printf '%s' "${PR_BODY:-}" | tr -d '\r' | awk -v pre="$attestation_prefix" -v suf="$attestation_suffix" '
+              found { next }
+              {
+                p = index($0, pre)
+                if (p == 0) next
+                rest = substr($0, p + length(pre))
+                s = index(rest, suf)
+                if (s == 0) next
+                print substr(rest, 1, s - 1)
+                found = 1
+              }
+            '
+          )"
+
+          if [ -z "$payload" ]; then
+            echo "::error::The no-mistakes pipeline attestation comment is malformed: no JSON payload could be extracted."
+            {
+              echo
+              echo "The '${attestation_prefix}' marker is present but is not closed by"
+              echo "'${attestation_suffix}' on the same line, or the payload is empty."
+              echo "This gate fails closed on an unreadable attestation."
+              echo
+              echo "PR author: ${PR_AUTHOR}"
+            } >&2
+            exit 1
+          fi
+
+          # Real JSON parsing. Emits one "<step>\t<verdict>\t<detail>" line per
+          # required step. A step recorded more than once must be completed in
+          # every record. Any skip-shaped sibling key (a future 'skipped',
+          # 'skip_reason', 'quota_...', '..._unavailable' field) with a meaningful
+          # value is rejected outright, so a skip can never ride along on a
+          # 'completed' status.
+          if ! report="$(
+            printf '%s' "$payload" | jq -r --argjson required '["review","test","document"]' '
+              if type != "object" then error("attestation payload is not a JSON object") else . end
+              | if (.steps | type) != "array" then error("attestation payload has no \"steps\" array") else . end
+              | . as $attestation
+              | $required[]
+              | . as $name
+              | [ $attestation.steps[] | select((type == "object") and ((.step? | tostring) == $name)) ] as $records
+              | if ($records | length) == 0 then
+                  "\($name)\tmissing\tno record in attestation"
+                else
+                  ([ $records[] | (.status? // null) | tostring ] | unique) as $statuses
+                  | ([ $records[]
+                       | to_entries[]
+                       | select((.key | ascii_downcase) | test("skip|quota|unavailable"))
+                       | select(.value != null and .value != false and .value != "")
+                       | .key ] | unique) as $skip_markers
+                  | if ($skip_markers | length) > 0 then
+                      "\($name)\tskip-marker\t\($skip_markers | join(","))"
+                    elif $statuses == ["completed"] then
+                      "\($name)\tok\tcompleted"
+                    else
+                      "\($name)\tbad\t\($statuses | join(","))"
+                    end
+                end
+            ' 2>&1
+          )"; then
+            echo "::error::The no-mistakes pipeline attestation payload could not be parsed as JSON."
+            {
+              echo
+              echo "jq reported:"
+              echo "$report"
+              echo
+              echo "Payload: $payload"
+              echo
+              echo "This gate fails closed on an unparseable attestation."
+              echo
+              echo "PR author: ${PR_AUTHOR}"
+            } >&2
+            exit 1
+          fi
+
+          echo "Attestation head_sha: $(printf '%s' "$payload" | jq -r '.head_sha // "(absent)"')"
+
+          tab="$(printf '\t')"
+          gate_status=0
+          checked=0
+          while IFS="$tab" read -r name verdict detail; do
+            [ -n "$name" ] || continue
+            checked=$((checked + 1))
+            case "$verdict" in
+              ok)
+                echo "  ok: ${name} = completed"
+                ;;
+              missing)
+                echo "::error::The no-mistakes pipeline attestation has no '${name}' step record; '${name}' must be recorded as completed."
+                gate_status=1
+                ;;
+              skip-marker)
+                echo "::error::The no-mistakes pipeline attestation marks '${name}' with skip indicator(s) [${detail}]; quota-exhaustion and agent-unavailability skips are not accepted."
+                gate_status=1
+                ;;
+              *)
+                echo "::error::The no-mistakes pipeline attestation records '${name}' as '${detail}', not 'completed'."
+                gate_status=1
+                ;;
+            esac
+          done <<REPORT
+          $report
+          REPORT
+
+          # A verdict per required step is the only shape jq can emit for a payload
+          # it accepted. Assert it anyway so an unexpected empty report fails closed
+          # instead of reporting nothing and passing.
+          if [ "$checked" -ne 3 ]; then
+            echo "::error::The no-mistakes attestation gate reached a verdict for ${checked} of the 3 required steps (review, test, document); failing closed."
+            gate_status=1
+          fi
+
+          if [ "$gate_status" -ne 0 ]; then
+            {
+              echo
+              echo "The no-mistakes review, test, and document steps must all be recorded as"
+              echo "'completed'. A step that was skipped (pre-skipped with --skip, skipped at a"
+              echo "gate, or skipped because the agent was unavailable or out of quota), failed,"
+              echo "or never finished is not accepted."
+              echo
+              echo "Re-run 'git push no-mistakes' and let review, test, and document run."
+              echo
+              echo "Attestation payload: $payload"
+              echo
+              echo "PR author: ${PR_AUTHOR}"
+            } >&2
+            exit 1
+          fi
+
+          echo "no-mistakes pipeline attestation verified for PR #${PR_NUMBER}: review, test, and document all completed."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,6 +89,7 @@ Any argv shape other than exactly one version flag falls through to `runAxiCli`,
   In a fresh clone, run `pnpm install --frozen-lockfile` before manual pack or publish.
   Verify with `npm pack --dry-run` (no source/test cruft; bin is `dist/bin/tasks-axi.js` with its shebang preserved by tsc).
 - **CI is a 3-OS matrix** (ubuntu/macos/windows) running install → build → lint → test → `build:skill --check`. The `Require no-mistakes` and `Guard generated files` checks gate every PR to `main`.
+- **The `Require no-mistakes` gate is mirrored verbatim from gh-axi.** Its inline `run:` script (signature + `no-mistakes-pipeline-attestation:v1` comment, requiring `review`/`test`/`document` all `completed`, failing closed on skip markers or malformed JSON) is copied byte-for-byte across the `*-axi` siblings; only this repo's `on:`/`if:`/`concurrency` are local. `test/workflows/no-mistakes-gate.test.ts` extracts that exact block from the YAML and executes it against fixtures, so edit the workflow, never a copy of the script.
 
 ## Follow-ups (out of P1 scope)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,7 +89,7 @@ Any argv shape other than exactly one version flag falls through to `runAxiCli`,
   In a fresh clone, run `pnpm install --frozen-lockfile` before manual pack or publish.
   Verify with `npm pack --dry-run` (no source/test cruft; bin is `dist/bin/tasks-axi.js` with its shebang preserved by tsc).
 - **CI is a 3-OS matrix** (ubuntu/macos/windows) running install → build → lint → test → `build:skill --check`. The `Require no-mistakes` and `Guard generated files` checks gate every PR to `main`.
-- **The `Require no-mistakes` gate is mirrored verbatim from gh-axi.** Its inline `run:` script (signature + `no-mistakes-pipeline-attestation:v1` comment, requiring `review`/`test`/`document` all `completed`, failing closed on skip markers or malformed JSON) is copied byte-for-byte across the `*-axi` siblings; only this repo's `on:`/`if:`/`concurrency` are local. `test/workflows/no-mistakes-gate.test.ts` extracts that exact block from the YAML and executes it against fixtures, so edit the workflow, never a copy of the script.
+- **The `Require no-mistakes` gate is mirrored verbatim from gh-axi.** Its inline `run:` script (signature + `no-mistakes-pipeline-attestation:v1` comment, requiring `review`/`test`/`document` all `completed`, failing closed on skip markers or malformed JSON) is copied byte-for-byte across the `*-axi` siblings; only this repo's `on:`/`if:`/`concurrency` are local. `test/workflows/no-mistakes-gate.test.ts` extracts that exact block from the YAML and executes it against fixtures, so edit the workflow, never a copy of the script. That test runs on the POSIX matrix legs only - Windows `jq` emits CRLF, which the ubuntu-only gate script has no reason to tolerate.
 
 ## Follow-ups (out of P1 scope)
 

--- a/test/workflows/no-mistakes-gate.test.ts
+++ b/test/workflows/no-mistakes-gate.test.ts
@@ -31,19 +31,24 @@ function extractGateScript(): string {
 const scriptPath = join(mkdtempSync(join(tmpdir(), "nm-gate-")), "gate.sh");
 writeFileSync(scriptPath, extractGateScript());
 
-// Probing the tool itself keeps this working on the Windows leg of the test
-// matrix, where `sh -c "command -v ..."` is not a reliable detector.
 function hasCommand(command: string): boolean {
-  return spawnSync(command, ["--version"], { stdio: "ignore" }).status === 0;
+  return spawnSync("sh", ["-c", `command -v ${command}`]).status === 0;
 }
 
 // The gate is a bash script that parses JSON with jq, exactly as the
-// ubuntu-latest runner that executes it does. Never skip on the POSIX CI legs:
-// a silently skipped gate test is worse than no test. Locally - and on the
-// Windows leg, which never runs this workflow - skip when bash or jq is absent
-// rather than failing over an unrelated missing tool.
-const runnable = hasCommand("bash") && hasCommand("jq");
-if (process.env.CI && !runnable && process.platform !== "win32") {
+// ubuntu-latest runner this workflow pins does - and only there. The Windows
+// leg of this repo's test matrix is deliberately excluded: its jq writes CRLF
+// line endings, so every verdict the script reads back would carry a trailing
+// \r and fail on an environment the gate never actually runs in. The gate
+// script must stay byte-identical to the sibling repos', so the platform is
+// filtered here rather than the script being made CRLF-tolerant.
+const posix = process.platform !== "win32";
+const runnable = posix && hasCommand("bash") && hasCommand("jq");
+
+// Never skip on the POSIX CI legs: a silently skipped gate test is worse than
+// no test. Locally, skip when bash or jq is absent rather than failing a
+// contributor's `pnpm test` over an unrelated missing tool.
+if (process.env.CI && posix && !runnable) {
   throw new Error(
     "CI must provide bash and jq to exercise the no-mistakes gate",
   );

--- a/test/workflows/no-mistakes-gate.test.ts
+++ b/test/workflows/no-mistakes-gate.test.ts
@@ -1,0 +1,213 @@
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { parse } from "yaml";
+
+const root = fileURLToPath(new URL("../..", import.meta.url));
+const workflowPath = join(
+  root,
+  ".github",
+  "workflows",
+  "no-mistakes-required.yml",
+);
+
+/**
+ * The gate lives as an inline `run:` block so the whole file can be mirrored
+ * into sibling repositories as one unit. Extract that exact block and execute
+ * it, so these tests exercise what CI runs rather than a copy of it.
+ */
+function extractGateScript(): string {
+  const doc = parse(readFileSync(workflowPath, "utf8")) as {
+    jobs: { check: { steps: Array<{ run?: string }> } };
+  };
+  const script = doc.jobs.check.steps[0]?.run;
+  if (!script) throw new Error("no-mistakes gate step has no run block");
+  return script;
+}
+
+const scriptPath = join(mkdtempSync(join(tmpdir(), "nm-gate-")), "gate.sh");
+writeFileSync(scriptPath, extractGateScript());
+
+// Probing the tool itself keeps this working on the Windows leg of the test
+// matrix, where `sh -c "command -v ..."` is not a reliable detector.
+function hasCommand(command: string): boolean {
+  return spawnSync(command, ["--version"], { stdio: "ignore" }).status === 0;
+}
+
+// The gate is a bash script that parses JSON with jq, exactly as the
+// ubuntu-latest runner that executes it does. Never skip on the POSIX CI legs:
+// a silently skipped gate test is worse than no test. Locally - and on the
+// Windows leg, which never runs this workflow - skip when bash or jq is absent
+// rather than failing over an unrelated missing tool.
+const runnable = hasCommand("bash") && hasCommand("jq");
+if (process.env.CI && !runnable && process.platform !== "win32") {
+  throw new Error(
+    "CI must provide bash and jq to exercise the no-mistakes gate",
+  );
+}
+
+function runGate(body: string): { code: number; output: string } {
+  const result = spawnSync("bash", [scriptPath], {
+    env: {
+      ...process.env,
+      PR_BODY: body,
+      PR_AUTHOR: "somedev",
+      PR_NUMBER: "42",
+    },
+    encoding: "utf8",
+  });
+  return {
+    code: result.status ?? -1,
+    output: `${result.stdout}${result.stderr}`,
+  };
+}
+
+const SIGNATURE =
+  "Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)";
+const ATTESTATION_PREFIX = "<!-- no-mistakes-pipeline-attestation:v1 ";
+const ATTESTATION_SUFFIX = " -->";
+const HEAD_SHA = "12df13109c6ad8d64646b85ac7170b23afe6e9bf";
+
+/** A PR body shaped like the one no-mistakes writes. */
+function prBody(attestationPayload?: string): string {
+  const attestation =
+    attestationPayload === undefined
+      ? ""
+      : `${ATTESTATION_PREFIX}${attestationPayload}${ATTESTATION_SUFFIX}\n\n`;
+  return [
+    "## What Changed\n\n- something\n",
+    `## Pipeline\n\n${SIGNATURE}\n\n${attestation}`,
+    "<details>\n<summary>Review</summary>\n\nok\n\n</details>\n",
+  ].join("\n");
+}
+
+function attestation(steps: Array<[string, string]>): string {
+  return JSON.stringify({
+    head_sha: HEAD_SHA,
+    steps: steps.map(([step, status]) => ({ step, status })),
+  });
+}
+
+/** The step snapshot a healthy run produces when the PR body is written. */
+const HEALTHY_STEPS: Array<[string, string]> = [
+  ["intent", "completed"],
+  ["rebase", "completed"],
+  ["review", "completed"],
+  ["test", "completed"],
+  ["document", "completed"],
+  ["lint", "completed"],
+  ["push", "completed"],
+  ["pr", "running"],
+  ["ci", "pending"],
+];
+
+function withStatus(step: string, status: string): Array<[string, string]> {
+  return HEALTHY_STEPS.map(([name, current]) =>
+    name === step ? [name, status] : [name, current],
+  ) as Array<[string, string]>;
+}
+
+describe.runIf(runnable)("no-mistakes PR gate", () => {
+  it("accepts a body whose attestation completes review, test, and document", () => {
+    const { code, output } = runGate(prBody(attestation(HEALTHY_STEPS)));
+    expect(code).toBe(0);
+    expect(output).toContain("review, test, and document all completed");
+  });
+
+  it("still rejects a body with no no-mistakes signature", () => {
+    const { code, output } = runGate("## Intent\n\nhand-written body\n");
+    expect(code).toBe(1);
+    expect(output).toContain("was not raised through no-mistakes");
+    expect(output).toContain("git push no-mistakes");
+  });
+
+  it("rejects a signed body with no attestation and names the required version", () => {
+    const { code, output } = runGate(prBody());
+    expect(code).toBe(1);
+    expect(output).toContain("no pipeline attestation");
+    expect(output).toContain("no-mistakes >= 1.46.0 is required (PR 670)");
+  });
+
+  // Every skip route no-mistakes has - `--skip`, a user skip at a gate, an
+  // automatic pipeline skip, or a run that ran out of agent quota - lands on
+  // the raw `skipped` status, and an unavailable agent surfaces as `failed`.
+  for (const status of ["skipped", "failed", "running", "pending"]) {
+    it(`rejects an attestation whose test step is ${status}`, () => {
+      const { code, output } = runGate(
+        prBody(attestation(withStatus("test", status))),
+      );
+      expect(code).toBe(1);
+      expect(output).toContain(`records 'test' as '${status}'`);
+    });
+  }
+
+  it("rejects an attestation that omits a required step entirely", () => {
+    const steps = HEALTHY_STEPS.filter(([name]) => name !== "document");
+    const { code, output } = runGate(prBody(attestation(steps)));
+    expect(code).toBe(1);
+    expect(output).toContain("no 'document' step record");
+  });
+
+  it("rejects a required step recorded twice unless every record completed", () => {
+    const steps: Array<[string, string]> = [
+      ...HEALTHY_STEPS,
+      ["review", "skipped"],
+    ];
+    const { code, output } = runGate(prBody(attestation(steps)));
+    expect(code).toBe(1);
+    expect(output).toContain("records 'review' as 'completed,skipped'");
+  });
+
+  // v1 carries no skip sibling field, so `status` is the only skip channel
+  // today. Fail closed if a later schema ever hangs a skip reason off an
+  // otherwise-completed step instead of widening the gate silently.
+  for (const marker of [
+    { skip_reason: "quota exhausted" },
+    { skipped: true },
+    { agent_unavailable: true },
+    { quota_exhausted: true },
+  ]) {
+    const key = Object.keys(marker)[0];
+    it(`rejects a completed step carrying a ${key} marker`, () => {
+      const payload = JSON.stringify({
+        head_sha: HEAD_SHA,
+        steps: HEALTHY_STEPS.map(([step, status]) =>
+          step === "review" ? { step, status, ...marker } : { step, status },
+        ),
+      });
+      const { code, output } = runGate(prBody(payload));
+      expect(code).toBe(1);
+      expect(output).toContain(`skip indicator(s) [${key}]`);
+    });
+  }
+
+  it("fails closed on an attestation payload that is not valid JSON", () => {
+    const { code, output } = runGate(
+      prBody('{"head_sha":"abc","steps":[{"step":"review",'),
+    );
+    expect(code).toBe(1);
+    expect(output).toContain("could not be parsed as JSON");
+  });
+
+  it("fails closed when the payload has no steps array", () => {
+    const { code, output } = runGate(prBody('{"head_sha":"abc"}'));
+    expect(code).toBe(1);
+    expect(output).toContain("could not be parsed as JSON");
+  });
+
+  it("fails closed when the attestation comment is never closed", () => {
+    const body = `## Pipeline\n\n${SIGNATURE}\n\n${ATTESTATION_PREFIX}{"head_sha":"abc","steps":[]}\n`;
+    const { code, output } = runGate(body);
+    expect(code).toBe(1);
+    expect(output).toContain("no JSON payload could be extracted");
+  });
+
+  it("accepts a CRLF body", () => {
+    const body = prBody(attestation(HEALTHY_STEPS)).replace(/\n/g, "\r\n");
+    const { code } = runGate(body);
+    expect(code).toBe(0);
+  });
+});


### PR DESCRIPTION
## What changed

Mirrors the attestation-aware no-mistakes gate that landed on gh-axi `main` (kunchenguid/gh-axi#111).

- `.github/workflows/no-mistakes-required.yml`: the gate step's `run:` script is now **byte-for-byte identical** to gh-axi's (verified by parsing both YAML files and comparing `jobs.check.steps[0].run` - 6583 bytes, equal). The signature check keeps its existing failure path; on top of it the gate now requires the `<!-- no-mistakes-pipeline-attestation:v1 {...} -->` comment, jq-parses `steps[]`, and requires `review`/`test`/`document` to all be `status == completed`. Signature present but attestation missing fails with the `no-mistakes >= 1.46.0 is required (PR 670)` message. Skip-shaped sibling keys (`skipped`, `skip_reason`, `quota_*`, `*_unavailable`) on an otherwise-completed step are rejected, and malformed/unparseable JSON fails closed.
- This repo's own `on:` (types/branches/`paths-ignore`), `concurrency`, `permissions`, the author-exemption `if:`, and the job name `PR must be raised via no-mistakes` are **unchanged**. Only the gate step's script (and its now-accurate step name) changed.
- New `test/workflows/no-mistakes-gate.test.ts`, mirroring gh-axi's `test/no-mistakes-gate.test.ts`: it parses the workflow YAML, extracts the exact inline block, writes it to a temp file and executes it with `bash` against fixture PR bodies - so the test exercises what CI runs, not a copy. Adapted to this repo's `test/workflows/` path and to the 3-OS matrix: `hasCommand` probes the tool directly (`bash --version`) instead of `sh -c "command -v ..."`, and the hard CI failure on a missing bash/jq applies to the POSIX legs only (the Windows leg never runs this workflow).
- `AGENTS.md`: one line recording that the gate script is a verbatim cross-repo mirror and that the test executes the extracted block.
- The gate test runs on the POSIX matrix legs only. The first CI run caught a real Windows-leg failure: Windows `jq` writes CRLF, so every verdict the script reads back through its `while read` loop carried a trailing `\r` (`records 'test' as 'running\r'`). The gate is an `ubuntu-latest`-only script and must stay byte-identical to the sibling repos', so the platform is filtered in the test rather than the script being made CRLF-tolerant. Second commit: `test: run the no-mistakes gate script on POSIX legs only`.

## CI on this PR

```
build-and-test (ubuntu-latest)        pass
build-and-test (macos-latest)         pass
build-and-test (windows-latest)       pass
Generated files must not be hand-edited  pass
PR must be raised via no-mistakes     fail   <- expected: direct PR, no signature
```

## Fixture-test transcript

```
$ npx vitest run test/workflows/no-mistakes-gate.test.ts --reporter=verbose

 RUN  v3.2.6 /Users/kunchen/.treehouse/tasks-axi-fb1fd8/1/tasks-axi

 ✓ no-mistakes PR gate > accepts a body whose attestation completes review, test, and document 103ms
 ✓ no-mistakes PR gate > still rejects a body with no no-mistakes signature 21ms
 ✓ no-mistakes PR gate > rejects a signed body with no attestation and names the required version 18ms
 ✓ no-mistakes PR gate > rejects an attestation whose test step is skipped 36ms
 ✓ no-mistakes PR gate > rejects an attestation whose test step is failed 29ms
 ✓ no-mistakes PR gate > rejects an attestation whose test step is running 37ms
 ✓ no-mistakes PR gate > rejects an attestation whose test step is pending 79ms
 ✓ no-mistakes PR gate > rejects an attestation that omits a required step entirely 31ms
 ✓ no-mistakes PR gate > rejects a required step recorded twice unless every record completed 81ms
 ✓ no-mistakes PR gate > rejects a completed step carrying a skip_reason marker 44ms
 ✓ no-mistakes PR gate > rejects a completed step carrying a skipped marker 81ms
 ✓ no-mistakes PR gate > rejects a completed step carrying a agent_unavailable marker 30ms
 ✓ no-mistakes PR gate > rejects a completed step carrying a quota_exhausted marker 30ms
 ✓ no-mistakes PR gate > fails closed on an attestation payload that is not valid JSON 24ms
 ✓ no-mistakes PR gate > fails closed when the payload has no steps array 62ms
 ✓ no-mistakes PR gate > fails closed when the attestation comment is never closed 17ms
 ✓ no-mistakes PR gate > accepts a CRLF body 64ms

 Test Files  1 passed (1)
      Tests  17 passed (17)
```

Full suite, lint, build, and the generated-skill check:

```
$ pnpm test
 Test Files  22 passed (22)
      Tests  447 passed (447)

$ pnpm lint      # eslint . - clean
$ pnpm build     # tsc - clean
$ pnpm run build:skill -- --check
skills/tasks-axi/SKILL.md is up to date.
```

## Note

This is a direct PR (internal CI tooling), so it carries no no-mistakes signature - the advisory `Require no-mistakes` check will fail on this PR by design. The real checks (build/test/guard-generated-files) must be green.
