### PR TITLE
ci: bind the no-mistakes attestation to the current PR head

### DIFF
--- a/.github/workflows/no-mistakes-required.yml
+++ b/.github/workflows/no-mistakes-required.yml
@@ -39,6 +39,7 @@ jobs:
           PR_BODY: ${{ github.event.pull_request.body }}
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           set -eu
           marker='Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)'
@@ -165,7 +166,31 @@ jobs:
             exit 1
           fi
 
-          echo "Attestation head_sha: $(printf '%s' "$payload" | jq -r '.head_sha // "(absent)"')"
+          attested_head="$(printf '%s' "$payload" | jq -r '.head_sha // ""')"
+          echo "Attestation head_sha: ${attested_head:-(absent)}"
+
+          # Head binding. The attestation describes the commit no-mistakes ran
+          # its steps on; a later push moves the PR head without rewriting the
+          # body, so an attestation that does not name the current head proves
+          # nothing about the code being merged. A `synchronize` whose body was
+          # NOT rewritten by no-mistakes going red is the intended contract, not
+          # a false positive.
+          if [ -z "$attested_head" ] || [ -z "${PR_HEAD_SHA:-}" ] || [ "$attested_head" != "$PR_HEAD_SHA" ]; then
+            echo "::error::The no-mistakes pipeline attestation is STALE for the current head of PR #${PR_NUMBER}."
+            {
+              echo
+              echo "Attestation head_sha: ${attested_head:-(absent)}"
+              echo "PR head sha:          ${PR_HEAD_SHA:-(absent)}"
+              echo
+              echo "A commit was pushed after the no-mistakes run, so the attestation does not"
+              echo "describe the code this PR now proposes to merge."
+              echo
+              echo "Re-run 'git push no-mistakes' to refresh it."
+              echo
+              echo "PR author: ${PR_AUTHOR}"
+            } >&2
+            exit 1
+          fi
 
           tab="$(printf '\t')"
           gate_status=0

--- a/test/workflows/no-mistakes-gate.test.ts
+++ b/test/workflows/no-mistakes-gate.test.ts
@@ -54,13 +54,17 @@ if (process.env.CI && posix && !runnable) {
   );
 }
 
-function runGate(body: string): { code: number; output: string } {
+function runGate(
+  body: string,
+  headSha: string = HEAD_SHA,
+): { code: number; output: string } {
   const result = spawnSync("bash", [scriptPath], {
     env: {
       ...process.env,
       PR_BODY: body,
       PR_AUTHOR: "somedev",
       PR_NUMBER: "42",
+      PR_HEAD_SHA: headSha,
     },
     encoding: "utf8",
   });
@@ -89,9 +93,12 @@ function prBody(attestationPayload?: string): string {
   ].join("\n");
 }
 
-function attestation(steps: Array<[string, string]>): string {
+function attestation(
+  steps: Array<[string, string]>,
+  headSha: string = HEAD_SHA,
+): string {
   return JSON.stringify({
-    head_sha: HEAD_SHA,
+    head_sha: headSha,
     steps: steps.map(([step, status]) => ({ step, status })),
   });
 }
@@ -188,6 +195,49 @@ describe.runIf(runnable)("no-mistakes PR gate", () => {
       expect(output).toContain(`skip indicator(s) [${key}]`);
     });
   }
+
+  // Head binding: the attestation describes the commit no-mistakes ran on, so
+  // an attestation naming any other commit says nothing about what is being
+  // merged. A synchronize whose body was not rewritten by no-mistakes going red
+  // is the contract, not a false positive.
+  it("accepts an attestation whose head_sha is the PR's current head", () => {
+    const { code, output } = runGate(
+      prBody(attestation(HEALTHY_STEPS, HEAD_SHA)),
+      HEAD_SHA,
+    );
+    expect(code).toBe(0);
+    expect(output).toContain(`Attestation head_sha: ${HEAD_SHA}`);
+  });
+
+  it("rejects an attestation whose head_sha is not the PR's current head", () => {
+    const staleSha = "0000000000000000000000000000000000000000";
+    const { code, output } = runGate(
+      prBody(attestation(HEALTHY_STEPS, staleSha)),
+      HEAD_SHA,
+    );
+    expect(code).toBe(1);
+    expect(output).toContain("attestation is STALE for the current head");
+    expect(output).toContain("Re-run 'git push no-mistakes' to refresh it");
+    expect(output).toContain(staleSha);
+    expect(output).toContain(HEAD_SHA);
+  });
+
+  it("fails closed when the attestation carries no head_sha at all", () => {
+    const payload = JSON.stringify({
+      steps: HEALTHY_STEPS.map(([step, status]) => ({ step, status })),
+    });
+    const { code, output } = runGate(prBody(payload), HEAD_SHA);
+    expect(code).toBe(1);
+    expect(output).toContain("attestation is STALE for the current head");
+    expect(output).toContain("Attestation head_sha: (absent)");
+  });
+
+  it("fails closed when the PR head sha is unavailable", () => {
+    const { code, output } = runGate(prBody(attestation(HEALTHY_STEPS)), "");
+    expect(code).toBe(1);
+    expect(output).toContain("attestation is STALE for the current head");
+    expect(output).toMatch(/PR head sha: +\(absent\)/);
+  });
 
   it("fails closed on an attestation payload that is not valid JSON", () => {
     const { code, output } = runGate(


### PR DESCRIPTION
## What Changed

The `Require no-mistakes` gate parsed the `no-mistakes-pipeline-attestation:v1` comment and required review/test/document = completed, but it only *printed* the attestation's `head_sha` - it never compared it to the PR's current head. A commit pushed directly after a no-mistakes run therefore passed the gate on a stale attestation.

This ports lavish-axi `main`'s head-binding (PR #271) verbatim:

- `PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}` added to the gate step's `env:`.
- After the attestation payload parses, the gate extracts `head_sha` and fails with an `::error::` saying the attestation is STALE for the current head (a commit was pushed after the no-mistakes run; re-run `git push no-mistakes` to refresh it) unless it equals `$PR_HEAD_SHA`. Absent on either side fails closed too.
- Everything else is preserved: this repo's triggers, `paths-ignore`, bot exemptions, job name, and the rest of the script. The gate script is now byte-identical to lavish-axi's; the only file-level difference remains this repo's `paths-ignore` list (no `plugin.json`).

This is the attestation contract: a `synchronize` event whose PR body was NOT rewritten by no-mistakes going red is the intended behavior, not a false positive.

## Tests

`test/workflows/no-mistakes-gate.test.ts` (which extracts and executes the workflow's exact inline `run:` block) gains four head-binding cases, mirroring lavish's:

- accepts an attestation whose `head_sha` is the PR's current head
- rejects an attestation whose `head_sha` is not the current head (asserts the STALE error, the re-run hint, and both shas in the output)
- fails closed when the attestation carries no `head_sha` at all
- fails closed when the PR head sha is unavailable

`runGate` and `attestation` now take an optional head sha, defaulting to the existing `HEAD_SHA` constant, so every pre-existing case is unchanged.

## Transcript

```
$ npx vitest run test/workflows/no-mistakes-gate.test.ts
 ✓ test/workflows/no-mistakes-gate.test.ts (21 tests) 418ms
 Test Files  1 passed (1)
      Tests  21 passed (21)

$ pnpm build
$ tsc

$ pnpm lint
$ eslint .

$ pnpm test
 Test Files  22 passed (22)
      Tests  451 passed (451)

$ pnpm run build:skill -- --check
skills/tasks-axi/SKILL.md is up to date.
```

## Note

This is a direct PR for internal CI tooling, raised without the no-mistakes pipeline, so the advisory `Require no-mistakes` check will fail on it (no signature) - expected and non-blocking. Build/test/guard checks are the real signal.
