### PR TITLE
fix: make the generated skill defer to live CLI guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ The CLI layer never knows which backend is active — it only talks to the `Stor
 - `src/backends/markdown*.ts` — the only P1 backend.
 - `src/public-followup.ts` - authoritative versioned schema, strict privacy-safe validation, canonical encoding, immutable-field checks, relation/event readiness, and terminal-state invariants for `kind=public-followup`; `src/commands/public-followup.ts` owns its dedicated CLI state machine.
 - `src/commands/*` — one file per verb group; `src/view.ts` owns the read-side TOON projection; `src/confirm.ts` owns the write-side output (the `ok:` confirmation line, the `--json` payload, and `renderMutation`, which assembles both).
-- Shared helpers copied from the family: `args.ts`, `body.ts`, `format.ts`, `fields.ts`, `toon.ts`, `suggestions.ts`, `skill.ts`.
+- Shared helpers copied from the family: `args.ts`, `body.ts`, `format.ts`, `fields.ts`, `toon.ts`, `suggestions.ts`, `skill.ts` (minimal CLI-deferring stub generator).
 
 ## Markdown grammar invariants (the hard part — do not regress)
 
@@ -76,8 +76,8 @@ Any argv shape other than exactly one version flag falls through to `runAxiCli`,
 
 ## Build / test / ship
 
-- `pnpm build` (tsc), `pnpm test` (vitest, `test/` mirrors `src/`), `pnpm lint` (eslint), `pnpm run build:skill -- --check` (the generated `skills/tasks-axi/SKILL.md` is built from `DESCRIPTION` + `TOP_HELP` and must not drift — CI runs the check).
-- `skills/tasks-axi/SKILL.md` is generated — regenerate with `pnpm run build:skill` after changing the description or top-level help; never hand-edit it.
+- `pnpm build` (tsc), `pnpm test` (vitest, `test/` mirrors `src/`), `pnpm lint` (eslint), `pnpm run build:skill -- --check` (CI fails if `skills/tasks-axi/SKILL.md` drifts from `src/skill.ts`).
+- The shipped skill stays **minimal** and **defers to the CLI** for all actual guidance. Frontmatter (name/description/metadata) is the discovery surface; the body only says what tasks-axi is, when to reach for it, and pointers to `npx -y tasks-axi` (dashboard), `npx -y tasks-axi --help`, and `npx -y tasks-axi <command> --help`. tasks-axi CLI output is the single source of truth. Never re-duplicate CLI-owned commands, flags, or workflow steps into the skill - prefer a pointer. Never hand-edit `skills/tasks-axi/SKILL.md`; regenerate with `pnpm run build:skill`.
 - This repo is no-mistakes-gated; ship through `/no-mistakes`.
 
 ### Release & packaging (mirrors the `*-axi` siblings)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,7 @@ See the [no-mistakes quick start](https://kunchenguid.github.io/no-mistakes/star
 - Run the full gate before pushing: `pnpm build && pnpm lint && pnpm test && pnpm run build:skill -- --check`.
 - The CLI layer only talks to the `Store` interface; backends slot in behind it without touching command code.
 - Do not hand-edit `CHANGELOG.md` or `.release-please-manifest.json` - release-please owns them.
-- Do not hand-edit `skills/tasks-axi/SKILL.md` - it is generated from the CLI's own description and help by `pnpm run build:skill`. Regenerate and commit it after changing the description or top-level help; CI fails if it is stale.
+- Do not hand-edit `skills/tasks-axi/SKILL.md` - `pnpm run build:skill` generates a minimal CLI-deferring stub. Keep commands, flags, and workflows in CLI output as the single source of truth; regenerate and commit the skill after changing its generator or shared description. CI fails if it is stale.
 
 ## Release and Packaging
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,7 @@ See the [no-mistakes quick start](https://kunchenguid.github.io/no-mistakes/star
 - Run the full gate before pushing: `pnpm build && pnpm lint && pnpm test && pnpm run build:skill -- --check`.
 - The CLI layer only talks to the `Store` interface; backends slot in behind it without touching command code.
 - Do not hand-edit `CHANGELOG.md` or `.release-please-manifest.json` - release-please owns them.
-- Do not hand-edit `skills/tasks-axi/SKILL.md` - `pnpm run build:skill` generates a minimal CLI-deferring stub. Keep commands, flags, and workflows in CLI output as the single source of truth; regenerate and commit the skill after changing its generator or shared description. CI fails if it is stale.
+- Do not hand-edit `skills/tasks-axi/SKILL.md` - it is generated from `src/skill.ts`. After changing the generator or shared description, run `pnpm run build:skill` and commit the result; CI fails if it is stale.
 
 ## Release and Packaging
 

--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ pnpm lint          # eslint
 pnpm run build:skill -- --check   # fail if the generated skill is stale
 ```
 
-The installable skill is generated from the same description and help the CLI prints, so it can never drift.
+The generated installable skill is intentionally minimal and points agents to the live CLI for all commands, flags, and workflows. CLI output remains the single source of truth.
 
 ## Contributing
 

--- a/scripts/build-skill.ts
+++ b/scripts/build-skill.ts
@@ -1,5 +1,5 @@
-// Generates skills/tasks-axi/SKILL.md from the shared CLI guidance so the
-// installable skill never drifts from what `tasks-axi` prints.
+// Generates skills/tasks-axi/SKILL.md as a minimal stub that defers to the
+// live CLI for all actual guidance (see src/skill.ts).
 //
 //   pnpm run build:skill            # write the file
 //   pnpm run build:skill -- --check # fail (exit 1) if the committed file is stale

--- a/skills/tasks-axi/SKILL.md
+++ b/skills/tasks-axi/SKILL.md
@@ -13,48 +13,14 @@ metadata:
 
 Agent ergonomic task & backlog manager for the current workspace. Prefer this over hand-editing backlog.md for task state, dependency, or hold changes.
 
-You do not need tasks-axi installed globally - invoke it with `npx -y tasks-axi <command>`.
-If tasks-axi output shows a follow-up command starting with `tasks-axi`, run it as `npx -y tasks-axi ...` instead.
-
-tasks-axi operates on a hand-editable `backlog.md` in the current workspace (or the path set in `.tasks.toml`). It edits the file in place with a byte-exact round-trip, so the human-readable backlog stays the source of truth.
-
 ## When to use
 
 Use tasks-axi whenever a task touches the backlog: filing or dispatching work, moving a task through queued -> in flight -> done, recording a PR url or report path on completion, tracking blocked-by dependencies, pausing dispatch with structured holds, finding dispatchable ready work or intentionally held work, or trimming the Done list.
 
-## Workflow
+Get every command, flag, and workflow from the live CLI - it is the single source of truth:
 
-1. Run `npx -y tasks-axi` with no arguments for a dashboard of the current backlog - in flight work, queued work with blockers, and suggested next commands.
-2. Drill in verb-first: `list`, `show <id>`, `ready`, then mutate with `add`, `start`, `done`, `block`/`unblock`, `hold`/`unhold`, `update`.
-3. The long notes never appear in `list`; run `show <id> --full` to read a task's complete body before replacing it.
-4. `add` takes a caller-supplied id (the join key), e.g. `tasks-axi add fm-x "title" --kind ship --repo firstmate --start`; or pass `--mint` to generate a slug-xx id from the title.
-5. `done <id> --pr <url>` (or `--report <path>`) closes a task, records the link, and prunes the Done list (archived, never deleted). Then `ready` shows work it unblocked.
-6. `hold <id> --reason "<text>"` pauses dispatch without prose parsing; `ready` excludes active holds by default, and `ready --include-held` shows a separate held group.
-   Use `--until YYYY-MM-DD` for a date gate that becomes inactive on and after that date.
-7. Human-readable responses include contextual next-step hints under `help:` when there is a useful follow-up - follow them.
-8. `--json` mutation responses skip `help:` and return the deterministic result object instead.
+- `npx -y tasks-axi` - dashboard of the current backlog
+- `npx -y tasks-axi --help` - global usage
+- `npx -y tasks-axi <command> --help` - per-command usage
 
-## Commands
-
-```
-commands[19]:
-  (none)=dashboard, add, list, show, start, done, reopen, update, rm, block, unblock, hold, unhold, ready, public-followup, mv, prune, render, setup
-```
-
-Run `npx -y tasks-axi --help` for global flags, or `npx -y tasks-axi <command> --help` for per-command usage.
-
-## Tips
-
-- Output is TOON-encoded and token-efficient; the long task body is truncated by default - the whole point is that `list` stays cheap.
-  Use `--full` only when you need the complete notes.
-- Every write leads with an `ok:` line confirming the write result, including the resulting task state when the command changes one (e.g. `ok: start <id> -> In flight`, `ok: done <id> -> Done (pr <url>)`, `ok: render -> normalized <n>`), then state-aware next-step hints.
-  Mutations are idempotent and add `already: true` on a no-op; re-running is safe.
-- Pass `--json` to any mutation (`add`, `start`, `done`, `reopen`, `update`, `rm`, `block`, `unblock`, `hold`, `unhold`, `mv`, `prune`, `render`) for a machine-readable result object (`{ "ok": true, "action": ..., "task": { ... } }` or operation-specific result fields) instead of TOON - confirm a write deterministically without a follow-up read.
-- `block <id> --by <other>` and `unblock` manage the dependency graph; `hold <id> --reason "<text>" [--until YYYY-MM-DD]` and `unhold` manage structured dispatch pauses; `ready` lists only queued work with no unresolved blocker and no active hold.
-- Filter `list` with `--state`, `--repo`, `--kind`, `--blocked`, `--limit`, and add columns with `--fields a,b,c`.
-  Use `list --state held` or `--fields held,hold_reason,hold_kind,hold_until` when scanning active hold state.
-- Existing prose markers such as `HELD`, `PARKED`, `DEFERRED`, `CAPTAIN-DECISION`, and `do not dispatch` stay prose until intentionally migrated.
-  Preserve the original prose as the hold reason, then choose `captain`, `parked`, `future`, `load`, or `external` only when the text supports that bucket.
-- Note writes are inspect-then-update: run `show <id> --full`, then replace the curated current body with `update <id> --body "<text>"` or `--body-file <path>`.
-  Add `--archive-body` to preserve the superseded body in `note-archive.md`; `--title "<text>"` replaces the title; `render` normalizes the file; `mv <id> [<id>...] --to <path>` moves one or more tasks to another backlog in one atomic transaction - pass a whole connected set (a blocker and its dependents) to move it together and preserve its `blocked-by` links and reason strings; moves that would strand an endpoint are refused.
-- Free-form (no-id) backlog lines are preserved verbatim and are never modified.
+You do not need tasks-axi installed globally. If the CLI prints a follow-up starting with `tasks-axi`, run it as `npx -y tasks-axi ...` instead.

--- a/src/skill.ts
+++ b/src/skill.ts
@@ -1,4 +1,4 @@
-import { DESCRIPTION, TOP_HELP } from "./cli.js";
+import { DESCRIPTION } from "./cli.js";
 
 // Trigger string agents match against to auto-load the skill. Terse and
 // outcome-focused so it fires on "manage the backlog / track tasks" intents.
@@ -21,21 +21,13 @@ function yamlDoubleQuote(value: string): string {
 }
 
 /**
- * Extract the `commands[N]:` block from the top-level help so the skill's
- * command list can never drift from what `tasks-axi --help` prints.
- */
-export function extractCommandsBlock(): string {
-  const match = TOP_HELP.match(/^(commands\[\d+\]:\n(?: {2}.*\n)+)/m);
-  if (!match) {
-    throw new Error("Could not find commands block in TOP_HELP");
-  }
-  return match[1].trimEnd();
-}
-
-/**
- * Render the installable SKILL.md. The body is built from the same shared
- * guidance the CLI prints (description + top-level help), rewriting invocations
- * to non-interactive `npx -y tasks-axi ...` so the CLI comes along on demand.
+ * Render the installable SKILL.md as a minimal stub.
+ *
+ * Frontmatter is the skill's identity and discovery surface. The body only
+ * says what tasks-axi is, when to reach for it, and where to get live
+ * instructions: the CLI itself. Never bake CLI-owned commands, flags, or
+ * workflow steps here - an installed skill goes stale when the npm package
+ * is bumped, and `pnpm run build:skill` would re-inflate any such copy.
  */
 export function createSkillMarkdown(): string {
   return `---
@@ -53,49 +45,16 @@ metadata:
 
 ${DESCRIPTION}
 
-You do not need tasks-axi installed globally - invoke it with \`npx -y tasks-axi <command>\`.
-If tasks-axi output shows a follow-up command starting with \`tasks-axi\`, run it as \`npx -y tasks-axi ...\` instead.
-
-tasks-axi operates on a hand-editable \`backlog.md\` in the current workspace (or the path set in \`.tasks.toml\`). It edits the file in place with a byte-exact round-trip, so the human-readable backlog stays the source of truth.
-
 ## When to use
 
 Use tasks-axi whenever a task touches the backlog: filing or dispatching work, moving a task through queued -> in flight -> done, recording a PR url or report path on completion, tracking blocked-by dependencies, pausing dispatch with structured holds, finding dispatchable ready work or intentionally held work, or trimming the Done list.
 
-## Workflow
+Get every command, flag, and workflow from the live CLI - it is the single source of truth:
 
-1. Run \`npx -y tasks-axi\` with no arguments for a dashboard of the current backlog - in flight work, queued work with blockers, and suggested next commands.
-2. Drill in verb-first: \`list\`, \`show <id>\`, \`ready\`, then mutate with \`add\`, \`start\`, \`done\`, \`block\`/\`unblock\`, \`hold\`/\`unhold\`, \`update\`.
-3. The long notes never appear in \`list\`; run \`show <id> --full\` to read a task's complete body before replacing it.
-4. \`add\` takes a caller-supplied id (the join key), e.g. \`tasks-axi add fm-x "title" --kind ship --repo firstmate --start\`; or pass \`--mint\` to generate a slug-xx id from the title.
-5. \`done <id> --pr <url>\` (or \`--report <path>\`) closes a task, records the link, and prunes the Done list (archived, never deleted). Then \`ready\` shows work it unblocked.
-6. \`hold <id> --reason "<text>"\` pauses dispatch without prose parsing; \`ready\` excludes active holds by default, and \`ready --include-held\` shows a separate held group.
-   Use \`--until YYYY-MM-DD\` for a date gate that becomes inactive on and after that date.
-7. Human-readable responses include contextual next-step hints under \`help:\` when there is a useful follow-up - follow them.
-8. \`--json\` mutation responses skip \`help:\` and return the deterministic result object instead.
+- \`npx -y tasks-axi\` - dashboard of the current backlog
+- \`npx -y tasks-axi --help\` - global usage
+- \`npx -y tasks-axi <command> --help\` - per-command usage
 
-## Commands
-
-\`\`\`
-${extractCommandsBlock()}
-\`\`\`
-
-Run \`npx -y tasks-axi --help\` for global flags, or \`npx -y tasks-axi <command> --help\` for per-command usage.
-
-## Tips
-
-- Output is TOON-encoded and token-efficient; the long task body is truncated by default - the whole point is that \`list\` stays cheap.
-  Use \`--full\` only when you need the complete notes.
-- Every write leads with an \`ok:\` line confirming the write result, including the resulting task state when the command changes one (e.g. \`ok: start <id> -> In flight\`, \`ok: done <id> -> Done (pr <url>)\`, \`ok: render -> normalized <n>\`), then state-aware next-step hints.
-  Mutations are idempotent and add \`already: true\` on a no-op; re-running is safe.
-- Pass \`--json\` to any mutation (\`add\`, \`start\`, \`done\`, \`reopen\`, \`update\`, \`rm\`, \`block\`, \`unblock\`, \`hold\`, \`unhold\`, \`mv\`, \`prune\`, \`render\`) for a machine-readable result object (\`{ "ok": true, "action": ..., "task": { ... } }\` or operation-specific result fields) instead of TOON - confirm a write deterministically without a follow-up read.
-- \`block <id> --by <other>\` and \`unblock\` manage the dependency graph; \`hold <id> --reason "<text>" [--until YYYY-MM-DD]\` and \`unhold\` manage structured dispatch pauses; \`ready\` lists only queued work with no unresolved blocker and no active hold.
-- Filter \`list\` with \`--state\`, \`--repo\`, \`--kind\`, \`--blocked\`, \`--limit\`, and add columns with \`--fields a,b,c\`.
-  Use \`list --state held\` or \`--fields held,hold_reason,hold_kind,hold_until\` when scanning active hold state.
-- Existing prose markers such as \`HELD\`, \`PARKED\`, \`DEFERRED\`, \`CAPTAIN-DECISION\`, and \`do not dispatch\` stay prose until intentionally migrated.
-  Preserve the original prose as the hold reason, then choose \`captain\`, \`parked\`, \`future\`, \`load\`, or \`external\` only when the text supports that bucket.
-- Note writes are inspect-then-update: run \`show <id> --full\`, then replace the curated current body with \`update <id> --body "<text>"\` or \`--body-file <path>\`.
-  Add \`--archive-body\` to preserve the superseded body in \`note-archive.md\`; \`--title "<text>"\` replaces the title; \`render\` normalizes the file; \`mv <id> [<id>...] --to <path>\` moves one or more tasks to another backlog in one atomic transaction - pass a whole connected set (a blocker and its dependents) to move it together and preserve its \`blocked-by\` links and reason strings; moves that would strand an endpoint are refused.
-- Free-form (no-id) backlog lines are preserved verbatim and are never modified.
+You do not need tasks-axi installed globally. If the CLI prints a follow-up starting with \`tasks-axi\`, run it as \`npx -y tasks-axi ...\` instead.
 `;
 }

--- a/test/skill.test.ts
+++ b/test/skill.test.ts
@@ -1,31 +1,30 @@
 import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
-import { TOP_HELP } from "../src/cli.js";
-import {
-  createSkillMarkdown,
-  extractCommandsBlock,
-  SKILL_DESCRIPTION,
-} from "../src/skill.js";
+import { DESCRIPTION } from "../src/cli.js";
+import { createSkillMarkdown, SKILL_DESCRIPTION } from "../src/skill.js";
 
 function normalizeLineEndings(value: string): string {
   return value.replace(/\r\n/g, "\n");
 }
 
 describe("skill generation", () => {
-  it("extracts the commands block from TOP_HELP", () => {
-    const block = extractCommandsBlock();
-    expect(block).toContain("commands[");
-    expect(block).toContain("add, list, show");
-    // the block is a slice of the canonical help, so it can never drift
-    expect(TOP_HELP).toContain(block);
+  it("keeps frontmatter identity and defers instructions to the CLI", () => {
+    const md = createSkillMarkdown();
+    expect(md.startsWith("---\nname: tasks-axi\n")).toBe(true);
+    expect(md).toContain(JSON.stringify(SKILL_DESCRIPTION));
+    expect(md).toContain("metadata:");
+    expect(md).toContain(DESCRIPTION);
+    expect(md).toContain("`npx -y tasks-axi`");
+    expect(md).toContain("`npx -y tasks-axi --help`");
+    expect(md).toContain("`npx -y tasks-axi <command> --help`");
   });
 
-  it("renders frontmatter and the shared guidance", () => {
+  it("does not bake CLI-owned command, flag, or workflow text", () => {
     const md = createSkillMarkdown();
-    expect(md).toContain("name: tasks-axi");
-    expect(md).toContain(JSON.stringify(SKILL_DESCRIPTION));
-    expect(md).toContain("npx -y tasks-axi");
-    expect(md).toContain("## Commands");
+    expect(md).not.toContain("## Commands");
+    expect(md).not.toContain("## Tips");
+    expect(md).not.toContain("## Workflow");
+    expect(md).not.toMatch(/^commands\[\d+\]:/m);
   });
 
   it("matches the committed skill file (guards against drift)", () => {


### PR DESCRIPTION
## Intent

Fix tasks-axi's skill-fragmentation problem: cut skills/tasks-axi/SKILL.md drastically to a minimal stub that defers to the CLI as the single source of truth, via the GENERATOR so the contract holds on every regeneration. Same minimal-stub pattern the captain approved for lavish-axi, applied family-wide.

The skill duplicates instructions the tasks-axi CLI already prints (help / subcommand / dashboard). Users install the skill once and never update it when they bump the npm package, so the baked copy goes stale. The skill already opens well and defers, but it also bakes a Commands index, a long Tips flag-detail section, and exact-syntax Workflow steps that mirror the CLI.

CRITICAL: fix the GENERATOR (src/skill.ts, via scripts/build-skill.ts / pnpm run build:skill), not just the current output. CI runs pnpm run build:skill -- --check and fails on drift. A future regeneration must not re-inflate the skill.

Keep frontmatter (name/description/metadata). Body only: what tasks-axi is (one or two lines), when to reach for it, and pointers telling the agent to get actual instructions from the CLI: npx -y tasks-axi (dashboard), npx -y tasks-axi --help, and npx -y tasks-axi <command> --help. Remove the Commands index, the Tips flag-detail section, and exact-syntax duplication in Workflow.

Document the contract in tasks-axi AGENTS.md: the shipped skill stays minimal and defers to the CLI for all actual guidance (CLI output is the single source of truth); never re-duplicate CLI-owned instructions into the skill; prefer a pointer over restated detail.

The CLI itself is UNCHANGED: do not remove or shrink --help, subcommand, or dashboard output.

Do not merge. No Greptile on tasks-axi. Captain merges and decides the release.

## What Changed

- Simplified the generated tasks-axi skill to retain discovery metadata while directing agents to the live dashboard and CLI help.
- Removed duplicated command, workflow, and flag guidance from the generator and generated skill without changing CLI output.
- Updated tests and contributor documentation to enforce the minimal, CLI-deferring skill contract.

## Risk Assessment

🚨 High: The change is otherwise well-bounded, but the generated body directly contradicts an explicit authoritative acceptance constraint and should not merge without human resolution.

## Testing

Verified the generator emits the minimal CLI-deferring skill without drift, the focused skill tests pass, and the unchanged dashboard, top-level help, and command help remain available end to end. Initial invalid flag-order and external-cwd evidence attempts were discarded and repeated through supported interfaces.

<details>
<summary>Evidence: Regenerated minimal tasks-axi skill</summary>

Source: [Regenerated minimal tasks-axi skill](https://github.com/kunchenguid/tasks-axi/blob/a8bc0e23dea9905e1e8375f29fe5079f47298cec/.no-mistakes/evidence/fm/tasksaxi-skill-minimal-stub-r1/generated-SKILL.md)

```text
---
name: tasks-axi
description: "Manage a task backlog through the tasks-axi CLI - add, list, show, start, and complete tasks; track blocked-by dependencies, structured holds, and a ready queue; prune and normalize a hand-editable backlog.md. Use whenever a task touches backlog or task state: filing or dispatching work, recording a PR or report on completion, finding dispatchable or held work, or trimming the Done list."
user-invocable: false
author: Kun Chen (kunchenguid)
metadata:
  hermes:
    tags: [tasks, backlog, planning, dependencies]
    category: productivity
---

# tasks-axi

Agent ergonomic task & backlog manager for the current workspace. Prefer this over hand-editing backlog.md for task state, dependency, or hold changes.

## When to use

Use tasks-axi whenever a task touches the backlog: filing or dispatching work, moving a task through queued -> in flight -> done, recording a PR url or report path on completion, tracking blocked-by dependencies, pausing dispatch with structured holds, finding dispatchable ready work or intentionally held work, or trimming the Done list.

Get every command, flag, and workflow from the live CLI - it is the single source of truth:

- `npx -y tasks-axi` - dashboard of the current backlog
- `npx -y tasks-axi --help` - global usage
- `npx -y tasks-axi <command> --help` - per-command usage

You do not need tasks-axi installed globally. If the CLI prints a follow-up starting with `tasks-axi`, run it as `npx -y tasks-axi ...` instead.
```
</details>
<details>
<summary>Evidence: Live CLI dashboard, top-level help, and subcommand help transcript</summary>

Source: [Live CLI dashboard, top-level help, and subcommand help transcript](https://github.com/kunchenguid/tasks-axi/blob/a8bc0e23dea9905e1e8375f29fe5079f47298cec/.no-mistakes/evidence/fm/tasksaxi-skill-minimal-stub-r1/live-cli-transcript.txt)

```text
$ npx -y tasks-axi
bin: ~/.no-mistakes/worktrees/4ebfb4ced0b4/01M0RG9QSZ0FEVE7HREXJGB8A5/bin/tasks-axi.ts
description: "Agent ergonomic task & backlog manager for the current workspace. Prefer this over hand-editing backlog.md for task state, dependency, or hold changes."
in_flight: 0 tasks
queued: 0 tasks
public_followups: 0 obligations
done: 0 retained
help[3]:
  - Run `tasks-axi list` for the full backlog
  - Run `tasks-axi ready` to see unblocked queued work
  - "Run `tasks-axi add <id> \"<title>\" --start` to add and start a task"

$ npx -y tasks-axi --help
usage: tasks-axi [command] [args] [flags]
commands[19]:
  (none)=dashboard, add, list, show, start, done, reopen, update, rm, block, unblock, hold, unhold, ready, public-followup, mv, prune, render, setup
flags[4]:
  --backend <name> (after command), --file <path> (after command), --json (mutations: machine-readable result), --help, -v/-V/--version
examples:
  tasks-axi
  tasks-axi add homemux-h7 "owns HomeMux end to end" --kind secondmate --start
  tasks-axi list --state queued
  tasks-axi show homemux-h7 --full
  tasks-axi done sm-idle-handoff-q8 --pr https://github.com/o/r/pull/42
  tasks-axi block fm-x --by treehouse-lease-t4
  tasks-axi hold fm-x --reason "captain decision pending" --kind captain
  tasks-axi ready
  tasks-axi public-followup ready --json
  tasks-axi setup hooks

$ npx -y tasks-axi show --help
usage: tasks-axi show <id> [--full]
aliases: view
examples:
  tasks-axi show homemux-h7
  tasks-axi show homemux-h7 --full
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"d3a850fb5a4c7ef4955f6076cc64f6e7c5fe09ba","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Review** - 1 error</summary>

- ⚠️ `README.md:268` - The generator no longer embeds CLI help, but README.md still says the skill is generated from CLI description and help, while CONTRIBUTING.md:39 still directs regeneration after top-level help changes. Update both to describe the minimal CLI-deferring stub so contributor guidance does not preserve the retired anti-pattern.

🔧 Fix: Align skill documentation with minimal generator contract
1 error still open:

- 🚨 `src/skill.ts:58` - Intent requires the body to contain only what tasks-axi is, when to use it, and the three specified CLI pointers. This additional follow-up rewriting instruction (`tasks-axi` to `npx -y tasks-axi ...`) is CLI invocation guidance outside that closed list and contradicts the documented minimal-body contract at lines 26-30. Confirm whether this exception is intentional or remove it from the generator and generated skill.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `pnpm exec vitest run test/skill.test.ts`
- <code>`pnpm run build:skill` followed by `pnpm run build:skill -- --check`</code>
- `pnpm exec tsx bin/tasks-axi.ts`
- `pnpm exec tsx bin/tasks-axi.ts --help`
- `pnpm exec tsx bin/tasks-axi.ts show --help`
- `Captured the regenerated skill and live CLI dashboard/help outputs as reviewer-visible evidence.`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
